### PR TITLE
Options and `basePath` addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Webpack plugin for generating an asset manifest.
 
 ## Usage
 
-In your webpack.config.js
+In your `webpack.config.js`
 
 ```javascript
 var ManifestPlugin = require('webpack-manifest-plugin');
@@ -19,3 +19,24 @@ module.exports = {
     ]
 };
 ```
+
+This will generate a `manifest.json` file in your root output directory with a mapping of all source file names to their corresponding output file, for example:
+
+```json
+{
+  "mods/alpha.js": "mods/alpha.1234567890.js",
+  "mods/omega.js": "mods/omega.0987654321.js"
+}
+```
+
+You may configure the manifest with options:
+
+```javascript
+new ManifestPlugin({
+  fileName: 'my-manifest.json',
+  basePath: '/app/'
+})
+```
+
+* `fileName`: The manifest filename in your output directory (`manifest.json` by default).
+* `basePath`: A path prefix for all file references. Useful for expressing output path within the manifest.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ This will generate a `manifest.json` file in your root output directory with a m
 }
 ```
 
-You may configure the manifest with options:
+
+## Configuration
+
+A manifest is configurable using constructor options:
 
 ```javascript
 new ManifestPlugin({
@@ -38,5 +41,7 @@ new ManifestPlugin({
 })
 ```
 
+**Options:**
+
 * `fileName`: The manifest filename in your output directory (`manifest.json` by default).
-* `basePath`: A path prefix for all file references. Useful for expressing output path within the manifest.
+* `basePath`: A path prefix for all file references. Useful for including your output path in the manifest.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,11 +2,12 @@ var fs = require('fs');
 var path = require('path');
 var _ = require('lodash');
 
-function ManifestPlugin() {
-  this.opts = {
+function ManifestPlugin(opts) {
+  this.opts = _.assign({
+    basePath: '',
     fileName: 'manifest.json',
     imageExtenstions: /(jpe?g|png|gif|svg)$/i
-  };
+  }, opts || {});
 };
 
 ManifestPlugin.prototype.getFileType = function(str) {
@@ -52,6 +53,15 @@ ManifestPlugin.prototype.apply = function(compiler) {
       return prevObj;
     }.bind(this), {}))
 
+    // Append optional basepath onto all references.
+    // This allows output path to be reflected in the manifest.
+    if (this.opts.basePath) {
+      manifest = _.reduce(manifest, function(memo, value, key) {
+        memo[this.opts.basePath + key] = this.opts.basePath + value;
+        return memo;
+      }.bind(this), {});
+    }
+    
     fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
   }.bind(this));
 };

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -19,7 +19,7 @@ function webpackCompile(opts, cb) {
       filename: '[name].js'
     },
     plugins: [
-      new plugin()
+      new plugin(opts.manifestOptions)
     ]
   }, opts);
 
@@ -79,6 +79,21 @@ describe('ManifestPlugin', function() {
         }
       }, function(manifest, stats){
         expect(manifest['one.js']).toEqual('one.' + stats.hash + '.js');
+        done();
+      });
+    });
+
+    it('prefixes definitions with a base path', function(done) {
+      webpackCompile({
+        manifestOptions: {basePath: '/app/'},
+        entry: {
+          one: path.join(__dirname, './fixtures/file.js'),
+        },
+        output: {
+          filename: '[name].[hash].js'
+        }
+      }, function(manifest, stats){
+        expect(manifest['/app/one.js']).toEqual('/app/one.' + stats.hash + '.js');
         done();
       });
     });


### PR DESCRIPTION
Good work, this plugin is definitely what I needed. A few additions though:

* Make manifest filename configurable through constructor options.
* Adding `basePath` option for prefixing all filepaths within the manifest. This is useful for including the build output location within all file references.