### PR TITLE
Added transformExtensions option for sourcemaps

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -9,7 +9,7 @@ function ManifestPlugin(opts) {
     stripSrc: null,
     imageExtensions: /(jpe?g|png|gif|svg)$/i
   }, opts || {});
-};
+}
 
 ManifestPlugin.prototype.getFileType = function(str) {
   return str.split('.').pop();
@@ -27,7 +27,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
     _.merge(manifest, Object.keys(assetsByChunkName).reduce(function(reducedObj, srcName){
       var chunkName = assetsByChunkName[srcName];
-      var srcName = srcName.replace(this.opts.stripSrc, '')
+      var srcName = srcName.replace(this.opts.stripSrc, '');
 
       if(Array.isArray(chunkName)) {
         var tmp = chunkName.reduce(function(prev, item){
@@ -53,7 +53,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }
 
       return prevObj;
-    }.bind(this), {}))
+    }.bind(this), {}));
 
     // Append optional basepath onto all references.
     // This allows output path to be reflected in the manifest.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -7,7 +7,7 @@ function ManifestPlugin(opts) {
     basePath: '',
     fileName: 'manifest.json',
     stripSrc: null,
-    imageExtenstions: /(jpe?g|png|gif|svg)$/i
+    imageExtensions: /(jpe?g|png|gif|svg)$/i
   }, opts || {});
 };
 
@@ -47,7 +47,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
     _.merge(manifest, stats.assets.reduce(function(prevObj, asset){
       var ext = this.getFileType(asset.name);
 
-      if (this.opts.imageExtenstions.test(ext)) {
+      if (this.opts.imageExtensions.test(ext)) {
         var trimmedName = asset.name.split('.').shift();
         prevObj[trimmedName + '.' + ext] = asset.name;
       }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -7,12 +7,18 @@ function ManifestPlugin(opts) {
     basePath: '',
     fileName: 'manifest.json',
     stripSrc: null,
-    imageExtensions: /(jpe?g|png|gif|svg)$/i
+    transformExtensions: /^(gz|map)$/i,
+    imageExtensions: /^(jpe?g|png|gif|svg)(\.|$)/i
   }, opts || {});
 }
 
 ManifestPlugin.prototype.getFileType = function(str) {
-  return str.split('.').pop();
+  var split = str.split('.');
+  var ext = split.pop();
+  if (this.opts.transformExtensions.test(ext)) {
+    ext = split.pop() + '.' + ext;
+  }
+  return ext;
 };
 
 ManifestPlugin.prototype.apply = function(compiler) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -20,14 +20,14 @@ ManifestPlugin.prototype.apply = function(compiler) {
   var outputPath = path.join(compiler.options.output.path, outputName);
 
   compiler.plugin('done', function(stats){
-    var stats = stats.toJson();
+    stats = stats.toJson();
     var assetsByChunkName = stats.assetsByChunkName;
 
     var manifest = {};
 
     _.merge(manifest, Object.keys(assetsByChunkName).reduce(function(reducedObj, srcName){
       var chunkName = assetsByChunkName[srcName];
-      var srcName = srcName.replace(this.opts.stripSrc, '');
+      srcName = srcName.replace(this.opts.stripSrc, '');
 
       if(Array.isArray(chunkName)) {
         var tmp = chunkName.reduce(function(prev, item){

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -83,6 +83,21 @@ describe('ManifestPlugin', function() {
       });
     });
 
+    it('works with source maps', function(done) {
+      webpackCompile({
+        devtool: 'sourcemap',
+        entry: {
+          one: path.join(__dirname, './fixtures/file.js'),
+        },
+        output: {
+          filename: '[name].js'
+        }
+      }, function(manifest, stats){
+        expect(manifest['one.js.map']).toEqual('one.js.map');
+        done();
+      });
+    });
+
     it('prefixes definitions with a base path', function(done) {
       webpackCompile({
         manifestOptions: {basePath: '/app/'},


### PR DESCRIPTION
ManifestPlugin currently doesn't handle sourcemap assets properly. `main.js.map` and `main.css.map` will result in a single output key, `main.map`. This is caused by the expectation of only a single file extension.

This is probably not the best way to solve this, but it works with minimal code changes. The `imageExtensions` RegExp was also changed to handle this. Additional extensions can easily be added for other modifiers. The change also includes a passing test for

Note: this branch is based off of [patch-1](https://github.com/jordansexton/webpack-manifest-plugin/tree/patch-1) (#3). I can change that and rebase if you like the PR but don't want to have to cherry pick around.