### PR TITLE
Emit manifest with assets

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,5 +1,3 @@
-var fs = require('fs');
-var path = require('path');
 var _ = require('lodash');
 
 function ManifestPlugin(opts) {
@@ -23,10 +21,9 @@ ManifestPlugin.prototype.getFileType = function(str) {
 
 ManifestPlugin.prototype.apply = function(compiler) {
   var outputName = this.opts.fileName;
-  var outputPath = path.join(compiler.options.output.path, outputName);
 
-  compiler.plugin('done', function(stats){
-    stats = stats.toJson();
+  compiler.plugin('emit', function(compilation, compileCallback){
+    var stats = compilation.getStats().toJson();
     var assetsByChunkName = stats.assetsByChunkName;
 
     var manifest = {};
@@ -70,7 +67,19 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }.bind(this), {});
     }
 
-    fs.writeFileSync(outputPath, JSON.stringify(manifest, null, 2));
+    var json = JSON.stringify(manifest, null, 2);
+
+    compilation.assets[outputName] = {
+      source: function() {
+        return json;
+      },
+      size: function() {
+        return json.length;
+      }
+    };
+
+    compileCallback()
+
   }.bind(this));
 };
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "css-loader": "^0.9.1",
     "extract-text-webpack-plugin": "^0.5.0",
     "jasmine": "^2.2.1",
-    "rimraf": "^2.3.2",
+    "memory-fs": "^0.2.0",
     "style-loader": "^0.8.3",
     "webpack": "^1.7.3"
   },

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -1,8 +1,7 @@
 var path = require('path');
-var fs = require('fs');
+var MemoryFileSystem = require("memory-fs");
 
 var webpack = require('webpack');
-var rimraf = require('rimraf');
 var _ = require('lodash');
 
 var plugin = require('../index.js');
@@ -23,21 +22,21 @@ function webpackCompile(opts, cb) {
     ]
   }, opts);
 
-  webpack(config, function(err, stats){
+  var compiler = webpack(config);
+
+  var fs = compiler.outputFileSystem = new MemoryFileSystem();
+
+  compiler.run(function(err, stats){
     var manifestFile = JSON.parse( fs.readFileSync(manifestPath).toString() );
 
     expect(err).toBeFalsy();
     expect(stats.hasErrors()).toBe(false);
 
     cb(manifestFile, stats);
-  });
+  })
 };
 
 describe('ManifestPlugin', function() {
-
-  beforeEach(function(done) {
-    rimraf(OUTPUT_DIR, done);
-  });
 
   it('exists', function() {
     expect(plugin).toBeDefined();


### PR DESCRIPTION
This fixes an issue I came across when trying to use this plugin with [`webpack-dev-middleware`](https://github.com/webpack/webpack-dev-middleware)

`webpack-dev-middleware` uses [`memory-fs`](https://github.com/webpack/memory-fs) instead of writing to disk. 
The issue was that when the plugin tried to write the manifest [here](https://github.com/danethurber/webpack-manifest-plugin/blob/b29088eaf942500a19587f826f37cc34ded5f33e/lib/plugin.js#L73) it would crash because the output dir would not exist since webpack was writing the files to memory.

I changed the plugin so it emits the `manifest.json` as a standard asset so that webpack will write it using whichever fs it is currently using.

regarding a test...
I started writing a specific test for running with `memory-fs` but then realized that if I change all tests to use `memory-fs` I can completely remove the need `rimraf`. 
This way compatibly with `memory-fs` is being tested without an explicit test.