### PR TITLE
Added readFile option

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,7 +8,8 @@ function ManifestPlugin(opts) {
     fileName: 'manifest.json',
     stripSrc: null,
     transformExtensions: /^(gz|map)$/i,
-    imageExtensions: /^(jpe?g|png|gif|svg)(\.|$)/i
+    imageExtensions: /^(jpe?g|png|gif|svg)(\.|$)/i,
+    readFile: false
   }, opts || {});
 }
 
@@ -28,8 +29,13 @@ ManifestPlugin.prototype.apply = function(compiler) {
   compiler.plugin('done', function(stats){
     stats = stats.toJson();
     var assetsByChunkName = stats.assetsByChunkName;
-
-    var manifest = {};
+    var manifest;
+    if (this.opts.readFile && fs.existsSync(outputPath)) {
+      manifest = JSON.parse(fs.readFileSync(outputPath).toString());
+    }
+    else {
+      manifest = {};
+    }
 
     _.merge(manifest, Object.keys(assetsByChunkName).reduce(function(reducedObj, srcName){
       var chunkName = assetsByChunkName[srcName];


### PR DESCRIPTION
When running webpack in multi-compiler mode, several builds may be compiling different parts of the application (server, desktop client, mobile clients, templates, etc.)

The current behavior of the plugin is to initialize the manifest to an empty object. This PR adds an option to read the existing manifest file if it exists, rather than starting from scratch.

This allows multiple compilations using this plugin may essentially write to the same manifest file. I've used this in production for 2 months now with no conflicts, since the reads and writes occur synchronously.