### PR TITLE
Don't include the basePath in manifest keys

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -62,7 +62,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
     // This allows output path to be reflected in the manifest.
     if (this.opts.basePath) {
       manifest = _.reduce(manifest, function(memo, value, key) {
-        memo[this.opts.basePath + key] = this.opts.basePath + value;
+        memo[key] = this.opts.basePath + value;
         return memo;
       }.bind(this), {});
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-manifest-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "webpack plugin for generating asset manifests",
   "main": "index.js",
   "scripts": {

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -107,7 +107,7 @@ describe('ManifestPlugin', function() {
           filename: '[name].[hash].js'
         }
       }, function(manifest, stats){
-        expect(manifest['/app/one.js']).toEqual('/app/one.' + stats.hash + '.js');
+        expect(manifest['one.js']).toEqual('/app/one.' + stats.hash + '.js');
         done();
       });
     });


### PR DESCRIPTION
We usually want to reference an asset by some key we know (its filename, e.g. `foo.js`) & get its real public path (e.g. `https://some.cdn.url/foo.1234.js`) in return.

If the basePath gets added to both the key & value in the manifest, it's impossible to do this.

Since it's a simple change I thought I'd just PR it rather than opening an issue, but curious if you have a use case for including basePath in the keys?

:smile: cheers!