### PR TITLE
Allow dots in image file names

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -58,7 +58,8 @@ ManifestPlugin.prototype.apply = function(compiler) {
       var ext = this.getFileType(asset.name);
 
       if (this.opts.imageExtensions.test(ext)) {
-        var trimmedName = asset.name.split('.').shift();
+        // trim '.[chunkhash].[ext]'
+        var trimmedName = asset.name.match(/(.*)\.[^.]+\.[^.]+$/)[1];
         prevObj[trimmedName + '.' + ext] = asset.name;
       }
 


### PR DESCRIPTION
Before this commit dots `.` in image file name would create broken manifest with a single key for all similar files. For example, these two images:

    name.one.123456789abcdef00001.png
    name.two.123456789abcdef00002.png

would previously create this broken manifest:

    { "name.png": "name.two.123456789abcdef00002.png" }