### PR TITLE
Handling of non-image, non-chunk assets; readFile changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ new ManifestPlugin({
 * `fileName`: The manifest filename in your output directory (`manifest.json` by default).
 * `basePath`: A path prefix for all file references. Useful for including your output path in the manifest.
 * `stripSrc`: removes unwanted strings from source filenames
+* `cache`: In [multi-compiler mode](https://github.com/webpack/webpack/tree/master/examples/multi-compiler) webpack will overwrite the manifest on each compilation. Passing a shared `{}` as the `cache` option into each compilation's ManifestPlugin will combine the manifest between compilations.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,3 +1,4 @@
+var path = require('path');
 var _ = require('lodash');
 
 function ManifestPlugin(opts) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -36,7 +36,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
   compiler.plugin('emit', function(compilation, compileCallback){
     var stats = compilation.getStats().toJson();
-    var assetsByChunkName = stats.assetsByChunkName;
+
     var manifest;
     if (this.opts.readFile && fs.existsSync(outputPath)) {
       manifest = JSON.parse(fs.readFileSync(outputPath).toString());
@@ -45,21 +45,14 @@ ManifestPlugin.prototype.apply = function(compiler) {
       manifest = {};
     }
 
-    _.merge(manifest, Object.keys(assetsByChunkName).reduce(function(reducedObj, srcName){
-      var chunkName = assetsByChunkName[srcName];
-      srcName = srcName.replace(this.opts.stripSrc, '');
+    _.merge(manifest, compilation.chunks.reduce(function(memo, chunk){
+      var chunkName = chunk.name.replace(this.opts.stripSrc, '');
 
-      if(Array.isArray(chunkName)) {
-        var tmp = chunkName.reduce(function(prev, item){
-          prev[srcName + '.' + this.getFileType(item)] = item;
-          return prev;
-        }.bind(this), {});
-        return _.merge(reducedObj, tmp);
-      }
-      else {
-        reducedObj[srcName + '.' + this.getFileType(chunkName)] = chunkName;
-        return reducedObj;
-      }
+      return chunk.files.reduce(function(memo, file){
+        memo[chunkName + '.' + this.getFileType(file)] = file;
+        return memo;
+      }.bind(this), memo);
+
     }.bind(this), {}));
 
     // module assets don't show up in assetsByChunkName.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -7,7 +7,6 @@ function ManifestPlugin(opts) {
     fileName: 'manifest.json',
     stripSrc: null,
     transformExtensions: /^(gz|map)$/i,
-    imageExtensions: /^(jpe?g|png|gif|svg)(\.|$)/i,
     readFile: false
   }, opts || {});
 }
@@ -24,6 +23,16 @@ ManifestPlugin.prototype.getFileType = function(str) {
 
 ManifestPlugin.prototype.apply = function(compiler) {
   var outputName = this.opts.fileName;
+  var moduleAssets = {};
+
+  compiler.plugin("compilation", function (compilation) {
+    compilation.plugin('module-asset', function (module, file) {
+      moduleAssets[file] = path.join(
+          path.dirname(file),
+          path.basename(module.userRequest)
+      );
+    });
+  });
 
   compiler.plugin('emit', function(compilation, compileCallback){
     var stats = compilation.getStats().toJson();
@@ -53,18 +62,15 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }
     }.bind(this), {}));
 
-    // images don't show up in assetsByChunkName.
+    // module assets don't show up in assetsByChunkName.
     // we're getting them this way;
-    _.merge(manifest, stats.assets.reduce(function(prevObj, asset){
-      var ext = this.getFileType(asset.name);
-
-      if (this.opts.imageExtensions.test(ext)) {
-        var trimmedName = asset.name.split('.').shift();
-        prevObj[trimmedName + '.' + ext] = asset.name;
+    _.merge(manifest, stats.assets.reduce(function(memo, asset){
+      var name = moduleAssets[asset.name];
+      if (name) {
+        memo[name] = asset.name;
       }
-
-      return prevObj;
-    }.bind(this), {}));
+      return memo;
+    }, {}));
 
     // Append optional basepath onto all references.
     // This allows output path to be reflected in the manifest.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -7,7 +7,7 @@ function ManifestPlugin(opts) {
     fileName: 'manifest.json',
     stripSrc: null,
     transformExtensions: /^(gz|map)$/i,
-    readFile: false
+    cache: null
   }, opts || {});
 }
 
@@ -23,6 +23,7 @@ ManifestPlugin.prototype.getFileType = function(str) {
 
 ManifestPlugin.prototype.apply = function(compiler) {
   var outputName = this.opts.fileName;
+  var cache = this.opts.cache || {};
   var moduleAssets = {};
 
   compiler.plugin("compilation", function (compilation) {
@@ -36,28 +37,20 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
   compiler.plugin('emit', function(compilation, compileCallback){
     var stats = compilation.getStats().toJson();
+    var manifest = {};
 
-    var manifest;
-    if (this.opts.readFile && fs.existsSync(outputPath)) {
-      manifest = JSON.parse(fs.readFileSync(outputPath).toString());
-    }
-    else {
-      manifest = {};
-    }
-
-    _.merge(manifest, compilation.chunks.reduce(function(memo, chunk){
+    _.merge(cache, compilation.chunks.reduce(function(memo, chunk){
       var chunkName = chunk.name.replace(this.opts.stripSrc, '');
 
       return chunk.files.reduce(function(memo, file){
         memo[chunkName + '.' + this.getFileType(file)] = file;
         return memo;
       }.bind(this), memo);
-
     }.bind(this), {}));
 
     // module assets don't show up in assetsByChunkName.
     // we're getting them this way;
-    _.merge(manifest, stats.assets.reduce(function(memo, asset){
+    _.merge(cache, stats.assets.reduce(function(memo, asset){
       var name = moduleAssets[asset.name];
       if (name) {
         memo[name] = asset.name;
@@ -68,11 +61,15 @@ ManifestPlugin.prototype.apply = function(compiler) {
     // Append optional basepath onto all references.
     // This allows output path to be reflected in the manifest.
     if (this.opts.basePath) {
-      manifest = _.reduce(manifest, function(memo, value, key) {
+      cache = _.reduce(cache, function(memo, value, key) {
         memo[this.opts.basePath + key] = this.opts.basePath + value;
         return memo;
       }.bind(this), {});
     }
+
+    Object.keys(cache).sort().forEach(function (key) {
+      manifest[key] = cache[key];
+    });
 
     var json = JSON.stringify(manifest, null, 2);
 


### PR DESCRIPTION
This removes the sketchy extension whitelist for image types (refs. #11), and uses webpack's compilation events to solve a longstanding problem, how to map output assets possibly including hashes to inputs. I've run the tests and refactored until everything passed.

Edit: ~~This includes the two commits from #13, but I can cut them if there's a merge conflict.~~
It also overrides #11, but it actually solves the problem at the same time (manifest assets get uniquely associated with user inputs).