### PR TITLE
Limit image asset name to base name to allow path in name

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var path = require('path');
 
 function ManifestPlugin(opts) {
   this.opts = _.assign({
@@ -58,7 +59,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       var ext = this.getFileType(asset.name);
 
       if (this.opts.imageExtensions.test(ext)) {
-        var trimmedName = asset.name.split('.').shift();
+        var trimmedName = path.basename(asset.name).split('.').shift();
         prevObj[trimmedName + '.' + ext] = asset.name;
       }
 


### PR DESCRIPTION
This allows one to set a different output path for images (vs. what's defined for output.path).

"main.js": "bundles/main.js",
"assets/images/xyz.svg": "assets/images/xyz.svg"

should be

"main.js": "bundles/main.js",
"xyz.svg": "assets/images/xyz.svg"