### PR TITLE
Add subfolder support

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -11,6 +11,13 @@ function ManifestPlugin(opts) {
   }, opts || {});
 }
 
+ManifestPlugin.prototype.getFileName = function(chunkName, file) {
+  var dir = path.dirname(file);
+  var type = this.getFileType(file);
+  var filename = chunkName + '.' + type;
+  return path.join(dir, filename);
+}
+
 ManifestPlugin.prototype.getFileType = function(str) {
   str = str.replace(/\?.*/, '');
   var split = str.split('.');
@@ -43,7 +50,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       var chunkName = chunk.name.replace(this.opts.stripSrc, '');
 
       return chunk.files.reduce(function(memo, file){
-        memo[chunkName + '.' + this.getFileType(file)] = file;
+        memo[this.getFileName(chunkName, file)] = file;
         return memo;
       }.bind(this), memo);
     }.bind(this), {}));

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -143,6 +143,20 @@ describe('ManifestPlugin', function() {
         done();
       });
     });
+
+    it('respects subfolders', function(done) {
+      webpackCompile({
+        entry: path.join(__dirname, './fixtures/file.js'),
+        output: {
+          filename: 'javascripts/main.js'
+        }
+      }, function(manifest){
+        expect(manifest).toBeDefined();
+        expect(manifest['javascripts/main.js']).toBeDefined();
+        expect(manifest['javascripts/main.js']).toEqual('javascripts/main.js');
+        done();
+      });
+    })
   });
 
   describe('with ExtractTextPlugin', function(){


### PR DESCRIPTION
I export my files into subfolders:

```
...
output: {
    filename: 'javascripts/main-[hash].js',
  },
...
```

however this (great!) plugin was not picking up on that for `main.js` (and `main.css`), though it would for assets:

```
...
"images/foo.png": "images/foo-79a318e1a4e1bc0aac94b6ba2bbb3b2a.png",
"main.js": "javascripts/main-2ce5bbf6dc7dbe06a0e9.js",
"main.css": "stylesheets/main-2ce5bbf6dc7dbe06a0e9.css"
...
```

This diff will prepend any subfolders to `main.js`/`main.css`:

```
...
"images/foo.png": "images/foo-79a318e1a4e1bc0aac94b6ba2bbb3b2a.png",
"javascripts/main.js": "javascripts/main-2ce5bbf6dc7dbe06a0e9.js",
"javascripts/main.css": "stylesheets/main-2ce5bbf6dc7dbe06a0e9.css"
...
```

Not as familiar with the webpack plugin system, so if there's a "smarter" way to do this, by all means let me know :)
