### PR TITLE
Resolving relative paths

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -21,6 +21,26 @@ ManifestPlugin.prototype.getFileType = function(str) {
   return ext;
 };
 
+ManifestPlugin.prototype.resolvePath = function(basePath, fileName) {
+  var skip = 0,
+    prefix = basePath[0] === '/' ? '/' : '',
+    result = (basePath + '/' + fileName)
+    .split('/')
+    .filter(function(chunk) {
+      return chunk.length;
+    })
+    .reverse()
+    .reduce(function(result, chunk) {
+      if (chunk === '..') skip++;
+      else if (skip > 0) skip--;
+      else result.push(chunk);
+      return result;
+    }, [])
+    .reverse()
+    .join('/');
+  return prefix + result;
+};
+
 ManifestPlugin.prototype.apply = function(compiler) {
   var outputName = this.opts.fileName;
   var cache = this.opts.cache || {};
@@ -41,13 +61,11 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
     _.merge(cache, compilation.chunks.reduce(function(memo, chunk){
       var chunkName = chunk.name.replace(this.opts.stripSrc, '');
-
       return chunk.files.reduce(function(memo, file){
         memo[chunkName + '.' + this.getFileType(file)] = file;
         return memo;
       }.bind(this), memo);
     }.bind(this), {}));
-
     // module assets don't show up in assetsByChunkName.
     // we're getting them this way;
     _.merge(cache, stats.assets.reduce(function(memo, asset){
@@ -57,16 +75,16 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }
       return memo;
     }, {}));
-
     // Append optional basepath onto all references.
     // This allows output path to be reflected in the manifest.
     if (this.opts.basePath) {
       cache = _.reduce(cache, function(memo, value, key) {
-        memo[this.opts.basePath + key] = this.opts.basePath + value;
+        value = this.resolvePath(this.opts.basePath, value);
+        key = this.resolvePath(value, '../' + key);
+        memo[key] = value;
         return memo;
       }.bind(this), {});
     }
-
     Object.keys(cache).sort().forEach(function (key) {
       manifest[key] = cache[key];
     });

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -145,6 +145,84 @@ describe('ManifestPlugin', function() {
     });
   });
 
+  describe('resolves relative paths', function(){
+      it('with an absolute base path', function(done) {
+        webpackCompile({
+          manifestOptions: {basePath: '/app/sub/'},
+          entry: {
+            one: path.join(__dirname, './fixtures/file.js'),
+          },
+          output: {
+            filename: '../[name].[hash].js'
+          }
+        }, function(manifest, stats){
+          expect(manifest['/app/one.js']).toEqual('/app/one.' + stats.hash + '.js');
+          done();
+        });
+      });
+
+      it('with a relative base path', function(done) {
+        webpackCompile({
+          manifestOptions: {basePath: 'app/sub/'},
+          entry: {
+            one: path.join(__dirname, './fixtures/file.js'),
+          },
+          output: {
+            filename: '../[name].[hash].js'
+          }
+        }, function(manifest, stats){
+          expect(manifest['app/one.js']).toEqual('app/one.' + stats.hash + '.js');
+          done();
+        });
+      });
+
+      it('with missing base path', function(done) {
+        webpackCompile({
+          manifestOptions: {basePath: 'app/sub/'},
+          entry: {
+            one: path.join(__dirname, './fixtures/file.js'),
+          },
+          output: {
+            filename: '../[name].[hash].js'
+          }
+        }, function(manifest, stats){
+          expect(manifest['app/one.js']).toEqual('app/one.' + stats.hash + '.js');
+          done();
+        });
+      });
+
+      it('when ExtractTextPlugin', function(done){
+        webpackCompile({
+          entry: {
+            wStyles: [
+              path.join(__dirname, './fixtures/file.js'),
+              path.join(__dirname, './fixtures/style.css')
+            ]
+          },
+          output: {
+            filename: '../[name].js'
+          },
+          module: {
+            loaders: [{
+              test: /\.css$/,
+              loader: ExtractTextPlugin.extract('style', 'css')
+            }]
+          },
+          plugins: [
+            new plugin({basePath: '/app/sub/'}),
+            new ExtractTextPlugin('../[name].css', {
+              allChunks: true
+            })
+          ]
+        }, function(manifest, stats){
+          expect(manifest['/app/wStyles.js']).toEqual('/app/wStyles.js');
+          expect(manifest['/app/wStyles.css']).toEqual('/app/wStyles.css');
+          done();
+        });
+
+      });
+  })
+
   describe('with ExtractTextPlugin', function(){
     it('works when extracting css into a seperate file', function(done){
       webpackCompile({


### PR DESCRIPTION
Hi. I added a mechanism that resolves relative paths.

Scenario:
My opts.basePath path is '/assets' but I needed to put favicon in the root '../'.
Webpack-manifest-plugin did not resolve relative paths so I added it. 
