### PR TITLE
add publicPath functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ new ManifestPlugin({
 
 * `fileName`: The manifest filename in your output directory (`manifest.json` by default).
 * `basePath`: A path prefix for all file references. Useful for including your output path in the manifest.
+* `publicPath`: A path prefix used only on output files, similar to Webpack's  [output.publicPath](https://github.com/webpack/docs/wiki/configuration#outputpublicpath). Ignored if `basePath` was also provided.
 * `stripSrc`: removes unwanted strings from source filenames
 * `cache`: In [multi-compiler mode](https://github.com/webpack/webpack/tree/master/examples/multi-compiler) webpack will overwrite the manifest on each compilation. Passing a shared `{}` as the `cache` option into each compilation's ManifestPlugin will combine the manifest between compilations.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 function ManifestPlugin(opts) {
   this.opts = _.assign({
     basePath: '',
+    publicPath: '',
     fileName: 'manifest.json',
     stripSrc: null,
     transformExtensions: /^(gz|map)$/i,
@@ -69,6 +70,14 @@ ManifestPlugin.prototype.apply = function(compiler) {
     if (this.opts.basePath) {
       cache = _.reduce(cache, function(memo, value, key) {
         memo[this.opts.basePath + key] = this.opts.basePath + value;
+        return memo;
+      }.bind(this), {});
+    } else if (this.opts.publicPath) {
+      // Similar to basePath but only affects the value (similar to how
+      // output.publicPath turns require('foo/bar') into '/public/foo/bar', see
+      // https://github.com/webpack/docs/wiki/configuration#outputpublicpath
+      cache = _.reduce(cache, function(memo, value, key) {
+        memo[key] = this.opts.publicPath + value;
         return memo;
       }.bind(this), {});
     }

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -121,6 +121,37 @@ describe('ManifestPlugin', function() {
       });
     });
 
+    it('prefixes paths with a public path', function(done) {
+      webpackCompile({
+        manifestOptions: {publicPath: '/app/'},
+        entry: {
+          one: path.join(__dirname, './fixtures/file.js'),
+        },
+        output: {
+          filename: '[name].[hash].js'
+        }
+      }, function(manifest, stats){
+        expect(manifest['one.js']).toEqual('/app/one.' + stats.hash + '.js');
+        done();
+      });
+    });
+
+    it('prefixes definitions with a base path when public path is also provided', function(done) {
+      webpackCompile({
+        manifestOptions: {basePath: '/app/', publicPath: '/app/' },
+        entry: {
+          one: path.join(__dirname, './fixtures/file.js'),
+        },
+        output: {
+          filename: '[name].[hash].js'
+        }
+      }, function(manifest, stats){
+        expect(manifest['/app/one.js']).toEqual('/app/one.' + stats.hash + '.js');
+        expect(manifest['one.js']).toBe(undefined);
+        done();
+      });
+    });
+
     it('combines manifests of multiple compilations', function(done) {
       var cache = {};
       webpackCompile([{


### PR DESCRIPTION
this lets you generate a manifest that maps bundles/assets to public urls, similar to https://github.com/webpack/docs/wiki/configuration#outputpublicpath