### PR TITLE
increase lodash dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "homepage": "https://github.com/danethurber/webpack-manifest-plugin",
   "dependencies": {
-    "lodash": "^3.5.0"
+    "lodash": ">=3.5 <5"
   }
 }


### PR DESCRIPTION
Lodash v3 is no longer supported, and it looks like v4 does not introduce any breaking changes for this package.

Can we increase the range of the supported lodash dependency to include v4 as proposed in this PR? 

This would avoid unmet peer dependency warnings on `npm install` when using a supported version of lodash.