### PR TITLE
Option to emit to file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@ new ManifestPlugin({
 * `fileName`: The manifest filename in your output directory (`manifest.json` by default).
 * `basePath`: A path prefix for all file references. Useful for including your output path in the manifest.
 * `stripSrc`: removes unwanted strings from source filenames
+* `writeToFileEmit`: If set to `true` will emit to build folder and memory in combination with `webpack-dev-server`   
 * `cache`: In [multi-compiler mode](https://github.com/webpack/webpack/tree/master/examples/multi-compiler) webpack will overwrite the manifest on each compilation. Passing a shared `{}` as the `cache` option into each compilation's ManifestPlugin will combine the manifest between compilations.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var fse = require('fs-extra');
 var _ = require('lodash');
 
 function ManifestPlugin(opts) {
@@ -7,6 +8,7 @@ function ManifestPlugin(opts) {
     fileName: 'manifest.json',
     stripSrc: null,
     transformExtensions: /^(gz|map)$/i,
+    writeToFileEmit: false,
     cache: null
   }, opts || {});
 }
@@ -88,8 +90,14 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }
     };
 
-    compileCallback();
+    if (this.opts.writeToFileEmit) {
+      var outputFolder = compilation.options.output.path;
+      var outputFile = path.join(outputFolder, this.opts.fileName);
 
+      fse.outputFileSync(outputFile, json);
+    }
+
+    compileCallback();
   }.bind(this));
 };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/danethurber/webpack-manifest-plugin",
   "dependencies": {
+    "fs-extra": "^0.30.0",
     "lodash": "^3.5.0"
   }
 }


### PR DESCRIPTION
When using this plugin is conjunction with [webpack-dev-server](https://webpack.github.io/docs/webpack-dev-server.html) it will emit to memory only. This is preferred but in some use cases (eg. integration with rails) you also need the manifest file on the filesystem.

I've added a flag `writeToFileEmit` that will write the JSON output to the build folder as well.