### PR TITLE
Add webpack-dev-server support

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -39,12 +39,16 @@ ManifestPlugin.prototype.apply = function(compiler) {
     var stats = compilation.getStats().toJson();
     var manifest = {};
 
-    _.merge(cache, compilation.chunks.reduce(function(memo, chunk) {
+    _.merge(manifest, compilation.chunks.reduce(function(memo, chunk) {
       var chunkName = chunk.name ? chunk.name.replace(this.opts.stripSrc, '') : null;
 
       // Map original chunk name to output files.
       // For nameless chunks, just map the files directly.
       return chunk.files.reduce(function(memo, file) {
+        // Don't add hot updates to manifest
+        if (file.indexOf('hot-update') >= 0) {
+          return memo;
+        }
         if (chunkName) {
           memo[chunkName + '.' + this.getFileType(file)] = file;
         } else {
@@ -56,7 +60,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
     // module assets don't show up in assetsByChunkName.
     // we're getting them this way;
-    _.merge(cache, stats.assets.reduce(function(memo, asset) {
+    _.merge(manifest, stats.assets.reduce(function(memo, asset) {
       var name = moduleAssets[asset.name];
       if (name) {
         memo[name] = asset.name;
@@ -67,17 +71,17 @@ ManifestPlugin.prototype.apply = function(compiler) {
     // Append optional basepath onto all references.
     // This allows output path to be reflected in the manifest.
     if (this.opts.basePath) {
-      cache = _.reduce(cache, function(memo, value, key) {
+      manifest = _.reduce(manifest, function(memo, value, key) {
         memo[this.opts.basePath + key] = this.opts.basePath + value;
         return memo;
       }.bind(this), {});
     }
 
-    Object.keys(cache).sort().forEach(function(key) {
-      manifest[key] = cache[key];
+    Object.keys(manifest).sort().forEach(function(key) {
+      cache[key] = manifest[key];
     });
 
-    var json = JSON.stringify(manifest, null, 2);
+    var json = JSON.stringify(cache, null, 2);
 
     compilation.assets[outputName] = {
       source: function() {


### PR DESCRIPTION
feature: skip hot updates from manifest
fix: basePath was added to already cached manifest values on each compilation