### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "style-loader": "^0.8.3",
     "webpack": "^1.7.3"
   },
+  "files": ["index.js", "lib"],
   "repository": {
     "type": "git",
     "url": "https://github.com/danethurber/webpack-manifest-plugin.git"


### PR DESCRIPTION
Prevents `spec` from being published to NPM, saves about 6 KB from the package size.