### PR TITLE
Resolve paths

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -14,6 +14,10 @@ function ManifestPlugin(opts) {
   }, opts || {});
 }
 
+function resolvePath() {
+  return path.normalize(path.join.apply(path, arguments));
+}
+
 ManifestPlugin.prototype.getFileType = function(str) {
   str = str.replace(/\?.*/, '');
   var split = str.split('.');
@@ -75,7 +79,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
     // This allows output path to be reflected in the manifest.
     if (this.opts.basePath) {
       manifest = _.reduce(manifest, function(memo, value, key) {
-        memo[this.opts.basePath + key] = this.opts.basePath + value;
+        memo[resolvePath(this.opts.basePath, key)] = resolvePath(this.opts.basePath, value);
         return memo;
       }.bind(this), {});
     } else if (this.opts.publicPath) {
@@ -83,7 +87,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       // output.publicPath turns require('foo/bar') into '/public/foo/bar', see
       // https://github.com/webpack/docs/wiki/configuration#outputpublicpath
       manifest = _.reduce(manifest, function(memo, value, key) {
-        memo[key] = this.opts.publicPath + value;
+        memo[key] = resolvePath(this.opts.publicPath, value);
         return memo;
       }.bind(this), {});
     }

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -121,6 +121,36 @@ describe('ManifestPlugin', function() {
       });
     });
 
+    it('resolves base path', function(done) {
+      webpackCompile({
+        manifestOptions: {basePath: '/app/subfolder/../'},
+        entry: {
+          one: path.join(__dirname, './fixtures/file.js'),
+        },
+        output: {
+          filename: '[name].[hash].js'
+        }
+      }, function(manifest, stats){
+        expect(manifest['/app/one.js']).toEqual('/app/one.' + stats.hash + '.js');
+        done();
+      });
+    });
+
+    it('does not expose base path\'s parent folder', function(done) {
+      webpackCompile({
+        manifestOptions: {basePath: '/app/../../'},
+        entry: {
+          one: path.join(__dirname, './fixtures/file.js'),
+        },
+        output: {
+          filename: '[name].[hash].js'
+        }
+      }, function(manifest, stats){
+        expect(manifest['/one.js']).toEqual('/one.' + stats.hash + '.js');
+        done();
+      });
+    });
+
     it('prefixes paths with a public path', function(done) {
       webpackCompile({
         manifestOptions: {publicPath: '/app/'},
@@ -132,6 +162,36 @@ describe('ManifestPlugin', function() {
         }
       }, function(manifest, stats){
         expect(manifest['one.js']).toEqual('/app/one.' + stats.hash + '.js');
+        done();
+      });
+    });
+
+    it('resolves public path', function(done) {
+      webpackCompile({
+        manifestOptions: {publicPath: '/app/subfolder/../'},
+        entry: {
+          one: path.join(__dirname, './fixtures/file.js'),
+        },
+        output: {
+          filename: '[name].[hash].js'
+        }
+      }, function(manifest, stats){
+        expect(manifest['one.js']).toEqual('/app/one.' + stats.hash + '.js');
+        done();
+      });
+    });
+
+    it('does not expose public path\'s parent folder', function(done) {
+      webpackCompile({
+        manifestOptions: {basePath: '/app/../../'},
+        entry: {
+          one: path.join(__dirname, './fixtures/file.js'),
+        },
+        output: {
+          filename: '[name].[hash].js'
+        }
+      }, function(manifest, stats){
+        expect(manifest['/one.js']).toEqual('/one.' + stats.hash + '.js');
         done();
       });
     });

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -136,7 +136,7 @@ describe('ManifestPlugin', function() {
       });
     });
 
-    it('does not expose base path\'s parent folder', function(done) {
+    it('does not expose base path\'s parent', function(done) {
       webpackCompile({
         manifestOptions: {basePath: '/app/../../'},
         entry: {
@@ -181,9 +181,9 @@ describe('ManifestPlugin', function() {
       });
     });
 
-    it('does not expose public path\'s parent folder', function(done) {
+    it('does not expose public path\'s parent', function(done) {
       webpackCompile({
-        manifestOptions: {basePath: '/app/../../'},
+        manifestOptions: {publicPath: '/app/../../'},
         entry: {
           one: path.join(__dirname, './fixtures/file.js'),
         },
@@ -191,7 +191,7 @@ describe('ManifestPlugin', function() {
           filename: '[name].[hash].js'
         }
       }, function(manifest, stats){
-        expect(manifest['/one.js']).toEqual('/one.' + stats.hash + '.js');
+        expect(manifest['one.js']).toEqual('/one.' + stats.hash + '.js');
         done();
       });
     });


### PR DESCRIPTION
When populating the manifest, resolves `basePath`/`publicPath` with `key`/`value` (to resolve parent directory references).

So `/base/subfolder/../file.ext` becomes `/base/file.ext`.

Side benefit is trailing slashes on `basePath`/`publicPath` are now optional since `join` takes care of that for you.

Note that it uses `path.normalize(path.join())` instead of `path.resolve()` so that ancestors of `basePath`/`publicPath` are not exposed. (The approach could be simplified if that’s not a concern.) This results in invalid paths if an absolute path is specified with several parent directory references. E.g., `resolvePath('/absolute/../..', 'file.ext')` returns `'/file.ext'` (not valid), whereas `resolvePath('relative/../..', 'file.ext')` returns `'../file.ext'`.

<hr />

My particular use case was with `sass-loader` plus `file-loader` to export CSS-referenced images.
* `sass-loader` processing SCSS to `/static/css`.
* `file-loader` processing images with `outputPath=../images/` (which was relative to CSS output, so `/static/images`).
* `webpack-manifest-plugin` with `basePath` of `/static/css/` so that the manifest paths were absolute.

Before this change, an image would appear in the manifest as `/static/css/../images/file.ext`. With this change, it appears as `/static/images/file.ext`.