### PR TITLE
Allow publicPath and basePath together

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ new ManifestPlugin({
 **Options:**
 
 * `fileName`: The manifest filename in your output directory (`manifest.json` by default).
-* `basePath`: A path prefix for all file references. Useful for including your output path in the manifest.
-* `publicPath`: A path prefix used only on output files, similar to Webpack's  [output.publicPath](https://github.com/webpack/docs/wiki/configuration#outputpublicpath). Ignored if `basePath` was also provided.
+* `publicPath`: A path prefix for output files, similar to Webpack's [output.publicPath](https://webpack.js.org/configuration/output/#output-publicpath). For example, the manifest pair `"foo/bar.js":"foo/bar.123.js"` would become `"foo/bar.js":"public/foo/bar.123.js"`.
+* `basePath`: A path prefix for _all_ file references, similar to Webpack's [output.path](https://webpack.js.org/configuration/output/#output-path). For example, the manifest pair `"foo/bar.js":"foo/bar.123.js"` would become `"path/to/foo/bar.js":"path/to/foo/bar.123.js"`. Base path is applied after `publicPath`, so the prefixes may be stacked.
 * `stripSrc`: removes unwanted strings from source filenames (string or regexp)
 * `writeToFileEmit`: If set to `true` will emit to build folder and memory in combination with `webpack-dev-server`
 * `cache`: In [multi-compiler mode](https://github.com/webpack/webpack/tree/master/examples/multi-compiler) webpack will overwrite the manifest on each compilation. Passing a shared `{}` as the `cache` option into each compilation's ManifestPlugin will combine the manifest between compilations.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -75,19 +75,22 @@ ManifestPlugin.prototype.apply = function(compiler) {
       return memo;
     }, {}));
 
-    // Append optional basepath onto all references.
-    // This allows output path to be reflected in the manifest.
+    // Prepend an optional public path onto all manifest values,
+    // similar to Webpack's `output.publicPath` option. Example:
+    // {"foo/bar.js":"foo/bar.123.js"} becomes {"foo/bar.js":"public/foo/bar.123.js"}
+    if (this.opts.publicPath) {
+      manifest = _.reduce(manifest, function(memo, value, key) {
+        memo[key] = resolvePath(this.opts.publicPath, value);
+        return memo;
+      }.bind(this), {});
+    }
+
+    // Prepend an optional base path onto all manifest keys AND values.
+    // This allows Webpack's `output.path` to be reflected in the manifest. Example:
+    // {"foo/bar.js":"foo/bar.123.js"} becomes {"path/to/foo/bar.js":"path/to/foo/bar.123.js"}
     if (this.opts.basePath) {
       manifest = _.reduce(manifest, function(memo, value, key) {
         memo[resolvePath(this.opts.basePath, key)] = resolvePath(this.opts.basePath, value);
-        return memo;
-      }.bind(this), {});
-    } else if (this.opts.publicPath) {
-      // Similar to basePath but only affects the value (similar to how
-      // output.publicPath turns require('foo/bar') into '/public/foo/bar', see
-      // https://github.com/webpack/docs/wiki/configuration#outputpublicpath
-      manifest = _.reduce(manifest, function(memo, value, key) {
-        memo[key] = resolvePath(this.opts.publicPath, value);
         return memo;
       }.bind(this), {});
     }

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -255,7 +255,7 @@ describe('ManifestPlugin', function() {
       });
     });
 
-    it('prefixes definitions with a base path when public path is also provided', function(done) {
+    it('prefixes definitions with public path before base path when both are provided', function(done) {
       webpackCompile({
         context: __dirname,
         entry: {
@@ -267,11 +267,11 @@ describe('ManifestPlugin', function() {
       }, {
         manifestOptions: {
           basePath: '/app/',
-          publicPath: '/app/'
+          publicPath: '/public/'
         }
       }, function(manifest, stats) {
         expect(manifest).toEqual({
-          '/app/one.js': '/app/one.' + stats.hash + '.js'
+          '/app/one.js': '/app/public/one.' + stats.hash + '.js'
         });
 
         done();


### PR DESCRIPTION
Another adjustment for the v.2 overhaul: this cleans up the roles and responsibilities of `publicPath` and `basePath`. Two specific changes:

1. The public and base path options are no longer mutually exclusive; they may be used together. This alleviates each setting's individual limitations.
2. Base path gets applies _after_ public path so that the output files may be relativized, and then the whole build. This feels a lot more predictable than the two settings toggling each other.

This technically represents a breaking change, although there is low likelihood of consumer issues (given that there is literally _no_ reason to include `publicPath` in the presence of `basePath` at the moment). If consumers do currently define both options and their build breaks in v2, the fix is simple: just delete `publicPath`.