### PR TITLE
feat(basePath): use basePath for keys only

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ The manifest filename in your output directory.
 
 Type: `String`
 
-A path prefix for all file references. Useful for including your output path in the manifest.
+A path prefix for all keys. Useful for including your output path in the manifest.
 
 
 ### `publicPath`
 
 Type: `String`
 
-A path prefix used only on output files, similar to Webpack's  [output.publicPath](https://github.com/webpack/docs/wiki/configuration#outputpublicpath). Ignored if `basePath` was also provided.
+A path prefix used only on output files, similar to Webpack's  [output.publicPath](https://github.com/webpack/docs/wiki/configuration#outputpublicpath).
 
 
 ### `stripSrc`

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -96,10 +96,11 @@ ManifestPlugin.prototype.apply = function(compiler) {
     if (this.opts.basePath) {
       files = files.map(function(file) {
         file.name = this.opts.basePath + file.name;
-        file.path = this.opts.basePath + file.path;
         return file;
       }.bind(this));
-    } else if (this.opts.publicPath) {
+    }
+
+    if (this.opts.publicPath) {
       // Similar to basePath but only affects the value (similar to how
       // output.publicPath turns require('foo/bar') into '/public/foo/bar', see
       // https://github.com/webpack/docs/wiki/configuration#outputpublicpath

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -143,7 +143,7 @@ describe('ManifestPlugin', function() {
         }
       }, function(manifest, stats) {
         expect(manifest).toEqual({
-          '/app/one.js': '/app/one.' + stats.hash + '.js'
+          '/app/one.js': 'one.' + stats.hash + '.js'
         });
 
         done();
@@ -210,7 +210,7 @@ describe('ManifestPlugin', function() {
         }
       }, function(manifest, stats) {
         expect(manifest).toEqual({
-          'https://www/example.com/one.js': 'https://www/example.com/one.js'
+          'https://www/example.com/one.js': 'one.js'
         });
 
         done();


### PR DESCRIPTION
BREAKING CHANGE:
- basePath is not ignored when publicPath is used
- basepath is only modifying manifest keys

closes #69 