### PR TITLE
Copy plugin integration

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -28,6 +28,19 @@ ManifestPlugin.prototype.getFileType = function(str) {
   return ext;
 };
 
+ManifestPlugin.prototype.existAssetInFiles = function(asset, files) {
+
+  if (path.extname(path.basename(asset.name, '.json')) === '.hot-update') {
+    return true;
+  }
+
+  // name is not in files already
+  return undefined !== _.find(files, function(file) {
+    var chunkName = path.basename(file.name, path.extname(file.name));
+    return file.path === asset.name || asset.chunkNames.indexOf(chunkName) !== -1;
+  });
+};
+
 ManifestPlugin.prototype.apply = function(compiler) {
   var outputName = this.opts.fileName;
   var seed = this.opts.seed || this.opts.cache || {};

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -91,6 +91,17 @@ ManifestPlugin.prototype.apply = function(compiler) {
     files = stats.assets.reduce(function (files, asset) {
       var name = moduleAssets[asset.name];
       if (!name) {
+        if (!this.existAssetInFiles(asset, files)) {
+          files.push({
+            path: asset.name,
+            name: asset.name,
+            isInitial: false,
+            isChunk: false,
+            isAsset: true,
+            isModuleAsset: false
+          });
+        }
+
         return files;
       }
 
@@ -102,7 +113,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
         isAsset: true,
         isModuleAsset: true
       });
-    }, files);
+    }.bind(this), files);
 
     // Append optional basepath onto all references.
     // This allows output path to be reflected in the manifest.

--- a/spec/helpers/copy-plugin-mock.js
+++ b/spec/helpers/copy-plugin-mock.js
@@ -1,0 +1,26 @@
+function FakeCopyWebpackPlugin() {
+};
+
+/**
+ * Mock plugins that modifies `compilation.assets`
+ *
+ * @param compiler
+ */
+FakeCopyWebpackPlugin.prototype.apply = function (compiler) {
+  compiler.plugin('emit', function (compilation, callback) {
+
+    var compiledMock = '// some compilation result\n';
+    compilation.assets['third.party.js'] = {
+      size: function () {
+        return compiledMock.length;
+      },
+      source: function () {
+        return compiledMock;
+      }
+    };
+
+    callback();
+  });
+};
+
+module.exports = FakeCopyWebpackPlugin;

--- a/spec/helpers/copy-plugin-mock.js
+++ b/spec/helpers/copy-plugin-mock.js
@@ -1,11 +1,6 @@
 function FakeCopyWebpackPlugin() {
 };
 
-/**
- * Mock plugins that modifies `compilation.assets`
- *
- * @param compiler
- */
 FakeCopyWebpackPlugin.prototype.apply = function (compiler) {
   compiler.plugin('emit', function (compilation, callback) {
 

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -477,7 +477,7 @@ describe('ManifestPlugin', function() {
           var manifest = JSON.parse(fs.readFileSync(manifestPath).toString());
 
           expect(manifest).toEqual({
-           'main.js': 'main.js'
+            'main.js': 'main.js'
           });
 
           done();
@@ -500,7 +500,7 @@ describe('ManifestPlugin', function() {
           var manifest = JSON.parse(fs.readFileSync(manifestPath).toString());
 
           expect(manifest).toEqual({
-           'main.js': 'main.js'
+            'main.js': 'main.js'
           });
 
           done();


### PR DESCRIPTION
Hi @mastilver,
This is the follow up of danethurber/webpack-manifest-plugin#45. Unfortunately I will not have more time these days until next week for the project.

I need help here also with [these lines](https://github.com/davidmpaz/webpack-manifest-plugin/commit/d2cb47f2c8ebb522c7581ec888ee77537fb4e4c5#diff-f85c36a1cc8952fb5e6fc7200a89ceaaR31), in the function `existAssetInFiles`. From tests I was getting an edge case for files ending in: `.hot-update.json`. Currently the solution I found was that you see there. But honestly I dont know from where that comes and whether this is the right way to check if the asset was included already. Please could you take a look and improve from there?

Things we can have in mind: 

If there is something we could do from [copy-webpack-plugin](https://github.com/kevlened/copy-webpack-plugin) side to make easier that check, I can make a pull request to them. If you look at the [mock plugin](https://github.com/davidmpaz/webpack-manifest-plugin/commit/63cf231fd77e2aca692b47c4bf91ec7a403289b9) what it does is asimilar to what [copy-webpack-plugin](https://github.com/kevlened/copy-webpack-plugin) does. Maybe we can add another data there to use later in here to filter easily. Some flag that does not interfere with standard things and so on like:
```
compilation.assets['third.party.js'] = {
       copied: true, // this is what I mean as flag, though dunno if correct.
       size: function () {
         return compiledMock.length;
       },
       source: function () {
         return compiledMock;
       }
}
```
So [in here](https://github.com/davidmpaz/webpack-manifest-plugin/commit/9438c1f77f8d40769abb0acfcd6db046f0a5eed3#diff-f85c36a1cc8952fb5e6fc7200a89ceaaR94) we can do something like:
```
if (asset.copied) {
......
}
```

Sorry for the long post.
regards