### PR TITLE
feat(plugin): Add plugin hook to allow other plugins to use the manifest

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -159,7 +159,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       fse.outputFileSync(outputFile, json);
     }
 
-    compileCallback();
+    compilation.applyPluginsAsync('webpack-manifest-plugin-after-emit', manifest, compileCallback)
   }.bind(this));
 };
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -159,7 +159,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       fse.outputFileSync(outputFile, json);
     }
 
-    compilation.applyPluginsAsync('webpack-manifest-plugin-after-emit', manifest, compileCallback)
+    compilation.applyPluginsAsync('webpack-manifest-plugin-after-emit', manifest, compileCallback);
   }.bind(this));
 };
 

--- a/spec/plugin.integration.spec.js
+++ b/spec/plugin.integration.spec.js
@@ -60,6 +60,42 @@ describe('ManifestPlugin using real fs', function() {
         done();
       });
     });
+
+    it('exposes a plugin hook with the manifest content', function (done) {
+      function TestPlugin() {
+        this.manifest = null;
+      }
+      TestPlugin.prototype.apply = function (compiler) {
+        var self = this;
+        compiler.plugin('compilation', function (compilation) {
+          compilation.plugin('webpack-manifest-plugin-after-emit', function (manifest, callback) {
+            self.manifest = manifest;
+            callback();
+          });
+        });
+      };
+
+      var testPlugin = new TestPlugin();
+      webpackCompile({
+        context: __dirname,
+        output: {
+          filename: '[name].js',
+          path: path.join(__dirname, 'output/single-file')
+        },
+        entry: './fixtures/file.js',
+        plugins: [
+          new ManifestPlugin(),
+          testPlugin
+        ]
+      }, {}, function() {
+        expect(testPlugin.manifest).toBeDefined();
+        expect(testPlugin.manifest).toEqual({
+          'main.js': 'main.js'
+        });
+
+        done();
+      });
+    });
   });
 
   describe('watch mode', function() {


### PR DESCRIPTION
Hello there 😃 

My team has very specific needs for our build process and we are currently developing a Webpack Plugin that needs the entry and output filenames. We could do this on our own but it would be pointless to duplicate the code that is in the `webpack-manifest-plugin`. So we make a proposal to add a Webpack plugin hook to your plugin that will allow any plugin to hook itself to yours to pull the manifest.

I used the `applyPluginsAsync` function because the hook that I registered is post emit so no transformation could be applied and therefore there's no need to use waterfall or series.

I thought about adding also a hook before `Json.stringify` but I think that there's more probability that `webpack-manifest-plugin` hooks on other plugins to generate the manifest than other plugins hooking to `webpack-manifest-plugin` to edit it.

The hook is `webpack-manifest-plugin-after-emit` with one argument containing the whole manifest.

Does it sounds good to you ?

Thanks for your work !