### PR TITLE
adds sort option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Type: `function`
 
 Modify files details before the manifest is created. [more details](#hooks-options)
 
+### `sort`
+
+Type: `function`<br>
+Default: in dependency order
+
+Sort files before they are passed to reduce. [more details](#hooks-options)
 
 ### `reduce`
 
@@ -119,7 +125,7 @@ Create the manifest. It can return anything as long as it's serialisable by `JSO
 
 ## Hooks Options
 
-`filter`, `map`, `reduce` takes as an input an Object with the following properties:
+`filter`, `map`, `sort`, `reduce` takes as an input an Object with the following properties:
 
 ### `path`
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var fse = require('fs-extra');
 var _ = require('lodash');
+var toposort = require('toposort');
 
 function ManifestPlugin(opts) {
   this.opts = _.assign({
@@ -44,8 +45,34 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
   compiler.plugin('emit', function(compilation, compileCallback) {
     var stats = compilation.getStats().toJson();
+    var nodeMap = {};
 
-    var files = compilation.chunks.reduce(function(files, chunk) {
+    compilation.chunks.forEach(function (chunk) {
+      nodeMap[chunk.id] = chunk;
+    });
+
+    // Next, we add an edge for each parent relationship into the graph
+    var edges = [];
+
+    compilation.chunks.forEach(function (chunk) {
+      if (chunk.parents) {
+        // Add an edge for each parent (parent -> child)
+        chunk.parents.forEach(function (parentId) {
+          // webpack2 chunk.parents are chunks instead of string id(s)
+          var parentChunk = _.isObject(parentId) ? parentId : nodeMap[parentId];
+          // If the parent chunk does not exist (e.g. because of an excluded chunk)
+          // we ignore that parent
+          if (parentChunk) {
+            edges.push([parentChunk, chunk]);
+          }
+        });
+      }
+    });
+
+    // We now perform a topological sorting on the input chunks and built edges
+    var chunks = toposort.array(compilation.chunks, edges);
+
+    var files = chunks.reduce(function(files, chunk) {
       return chunk.files.reduce(function (files, path) {
         // Don't add hot updates to manifest
         if (path.indexOf('hot-update') >= 0) {
@@ -118,18 +145,9 @@ ManifestPlugin.prototype.apply = function(compiler) {
       files = files.map(this.opts.map);
     }
 
-    files = files.sort(function (fileA, fileB) {
-      var a = fileA.name;
-      var b = fileB.name;
-
-      if (a < b) {
-          return -1;
-      } else if (a > b) {
-          return 1;
-      } else {
-          return 0;
-      }
-    });
+    if (this.opts.sort) {
+      files = files.sort(this.opts.sort);
+    }
 
     var manifest;
     if (this.opts.reduce) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "homepage": "https://github.com/danethurber/webpack-manifest-plugin",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "lodash": ">=3.5 <5"
+    "lodash": ">=3.5 <5",
+    "toposort": "^1.0.3"
   },
   "nyc": {
     "reporter": [

--- a/spec/fixtures/common.js
+++ b/spec/fixtures/common.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/spec/fixtures/main.js
+++ b/spec/fixtures/main.js
@@ -1,0 +1,2 @@
+require('./common.js');
+console.log('main');

--- a/spec/fixtures/util.js
+++ b/spec/fixtures/util.js
@@ -1,0 +1,2 @@
+require('./common.js');
+console.log('util');

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -90,6 +90,32 @@ describe('ManifestPlugin', function() {
       });
     });
 
+    it('multiple file output is dependency ordered', function(done) {
+      webpackCompile({
+        context: __dirname,
+        entry: {
+          main: './fixtures/main.js',
+          vendor: './fixtures/util.js'
+        },
+        plugins: [
+          new plugin({
+            seed: [],
+            reduce: function (manifest, file) {
+              return manifest.concat(file.name);
+            }
+          }),
+          new webpack.optimize.CommonsChunkPlugin({
+            name: 'common',
+            filename: 'common.js'
+          })
+        ]
+      }, {}, function(manifest) {
+        expect(manifest).toEqual(['common.js', 'vendor.js', 'main.js']);
+
+        done();
+      });
+    });
+
     it('works with hashes in the filename', function(done) {
       webpackCompile({
         context: __dirname,
@@ -575,6 +601,35 @@ describe('ManifestPlugin', function() {
         expect(manifest).toEqual({
           'javascripts/main.js': 'javascripts/main.js'
         });
+
+        done();
+      });
+    });
+  });
+
+  describe('sort', function() {
+    it('should allow ordering of output', function(done) {
+      webpackCompile({
+        context: __dirname,
+        entry: {
+          one: './fixtures/file.js',
+          two: './fixtures/file-two.js'
+        },
+        output: {
+          filename: '[name].js'
+        }
+      }, {
+        manifestOptions: {
+          seed: [],
+          sort: function(file, i) {
+            return 1;
+          },
+          reduce: function (manifest, file) {
+            return manifest.concat(file.name);
+          }
+        }
+      }, function(manifest, stats) {
+        expect(manifest).toEqual(['two.js', 'one.js']);
 
         done();
       });


### PR DESCRIPTION
Hello! Awesome plugin you've got here.
I was needing a way to have a sorted by dependency manifest (like how html-webpack-plugin works)
while I was looking around i found that i could adapt your plugin to do what I needed without affecting it's functionality in any way.
(by passing
```
  const manifestGenerator = (manifest, { name, path }) => [...manifest, path];


{
  seed: [],
  reduce: manifestGenerator,
  sort: x => -1
}
```
to the plugin, which gives me an array of filenames sorted by dependency.

I was hoping you might accept this PR

----------------------------

allows users to sort the file list before it is passed to reduce, can disable aphabetical sorting by passing () => -1

array passed to sort is presorted based on the dependency graph using topological sort on [parentChunk, chunk], this was adapted from html-webpack-plugin