### PR TITLE
feat: deprecate publicPath in flavour of webpack's

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,24 +34,28 @@ This will generate a `manifest.json` file in your root output directory with a m
 ```
 
 
-## Configuration
+## API:
 
-A manifest is configurable using constructor options:
+```js
+// webpack.config.js
 
-```javascript
-new ManifestPlugin({
-  fileName: 'my-manifest.json',
-  basePath: '/app/',
-  seed: {
-    name: 'My Manifest'
-  }
-})
+module.exports = {
+  output: {
+    publicPath
+  },
+  plugins: [
+    new ManifestPlugin(options)
+  ]
+}
 ```
 
+### `publicPath`
 
-## Options:
+Type: `String`
 
-### `fileName`
+A path prefix that will be added to values of the manifest.
+
+### `options.fileName`
 
 Type: `String`<br>
 Default: `manifest.json`
@@ -59,28 +63,21 @@ Default: `manifest.json`
 The manifest filename in your output directory.
 
 
-### `basePath`
+### `options.basePath`
 
 Type: `String`
 
 A path prefix for all keys. Useful for including your output path in the manifest.
 
 
-### `publicPath`
-
-Type: `String`
-
-A path prefix used only on output files, similar to Webpack's  [output.publicPath](https://github.com/webpack/docs/wiki/configuration#outputpublicpath).
-
-
-### `stripSrc`
+### `options.stripSrc`
 
 Type: `String`, `RegExp`
 
 Removes unwanted strings from source filenames.
 
 
-### `writeToFileEmit`
+### `options.writeToFileEmit`
 
 Type: `Boolean`<br>
 Default: `false`
@@ -88,28 +85,28 @@ Default: `false`
 If set to `true` will emit to build folder and memory in combination with `webpack-dev-server`
 
 
-### `seed`
+### `options.seed`
 
 Type: `Object`<br>
 Default: `{}`
 
 A cache of key/value pairs to used to seed the manifest. This may include a set of [custom key/value](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json) pairs to include in your manifest, or may be used to combine manifests across compilations in [multi-compiler mode](https://github.com/webpack/webpack/tree/master/examples/multi-compiler). To combine manifests, pass a shared seed object to each compiler's ManifestPlugin instance.
 
-### `filter`
+### `options.filter`
 
 Type: `function`
 
 Filter out files. [more details](#hooks-options)
 
 
-### `map`
+### `options.map`
 
 Type: `function`
 
 Modify files details before the manifest is created. [more details](#hooks-options)
 
 
-### `reduce`
+### `options.reduce`
 
 Type: `function`<br>
 Default: `(manifest, {name, path}) => ({...manifest, [name]: path})`

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -5,7 +5,6 @@ var _ = require('lodash');
 function ManifestPlugin(opts) {
   this.opts = _.assign({
     basePath: '',
-    publicPath: '',
     fileName: 'manifest.json',
     stripSrc: null,
     transformExtensions: /^(gz|map)$/i,
@@ -43,6 +42,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
   });
 
   compiler.plugin('emit', function(compilation, compileCallback) {
+    var publicPath = compilation.options.output.publicPath;
     var stats = compilation.getStats().toJson();
 
     var files = compilation.chunks.reduce(function(files, chunk) {
@@ -100,12 +100,12 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }.bind(this));
     }
 
-    if (this.opts.publicPath) {
+    if (publicPath) {
       // Similar to basePath but only affects the value (similar to how
       // output.publicPath turns require('foo/bar') into '/public/foo/bar', see
       // https://github.com/webpack/docs/wiki/configuration#outputpublicpath
       files = files.map(function(file) {
-        file.path = this.opts.publicPath + file.path;
+        file.path = publicPath + file.path;
         return file;
       }.bind(this));
     }

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -157,13 +157,10 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
-          filename: '[name].[hash].js'
-        }
-      }, {
-        manifestOptions: {
+          filename: '[name].[hash].js',
           publicPath: '/app/'
         }
-      }, function(manifest, stats) {
+      }, {}, function(manifest, stats) {
         expect(manifest).toEqual({
           'one.js': '/app/one.' + stats.hash + '.js'
         });
@@ -179,12 +176,12 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
-          filename: '[name].[hash].js'
+          filename: '[name].[hash].js',
+          publicPath: '/app/'
         }
       }, {
         manifestOptions: {
-          basePath: '/app/',
-          publicPath: '/app/'
+          basePath: '/app/'
         }
       }, function(manifest, stats) {
         expect(manifest).toEqual({
@@ -224,13 +221,10 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
-          filename: '[name].js'
-        }
-      }, {
-        manifestOptions: {
+          filename: '[name].js',
           publicPath: 'http://www/example.com/',
         }
-      }, function(manifest, stats) {
+      }, {}, function(manifest, stats) {
         expect(manifest).toEqual({
           'one.js': 'http://www/example.com/one.js'
         });
@@ -271,12 +265,12 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
-          filename: '[name].[hash].js'
+          filename: '[name].[hash].js',
+          publicPath: '/app/'
         }
       }, {
         manifestOptions: {
           basePath: '/app/',
-          publicPath: '/app/',
           seed: {
             test1: 'test2'
           }


### PR DESCRIPTION
BREAKING CHANGE: deprecate webpack-manifest-plugin's publicPath options in flavour of webpack's output.publicPAth

closes #65 