### PR TITLE
feat: deprecate cache in flavour of seed

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -9,7 +9,6 @@ function ManifestPlugin(opts) {
     stripSrc: null,
     transformExtensions: /^(gz|map)$/i,
     writeToFileEmit: false,
-    cache: null, // TODO: Remove `cache` in next major release in favour of `seed`.
     seed: null,
     filter: null,
     map: null,
@@ -29,7 +28,7 @@ ManifestPlugin.prototype.getFileType = function(str) {
 
 ManifestPlugin.prototype.apply = function(compiler) {
   var outputName = this.opts.fileName;
-  var seed = this.opts.seed || this.opts.cache || {};
+  var seed = this.opts.seed || {};
   var moduleAssets = {};
 
   compiler.plugin("compilation", function (compilation) {

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -311,32 +311,6 @@ describe('ManifestPlugin', function() {
       });
     });
 
-    it('still accepts cache parameter (deprecated)', function(done) {
-      var cache = {};
-      webpackCompile([{
-        context: __dirname,
-        entry: {
-          one: './fixtures/file.js'
-        }
-      }, {
-        context: __dirname,
-        entry: {
-          two: './fixtures/file-two.js'
-        }
-      }], {
-        manifestOptions: {
-          cache: cache
-        }
-      }, function(manifest) {
-        expect(manifest).toEqual({
-          'one.js': 'one.js',
-          'two.js': 'two.js'
-        });
-
-        done();
-      });
-    });
-
     it('outputs a manifest of no-js file', function(done) {
       webpackCompile({
         context: __dirname,


### PR DESCRIPTION
BREAKING CHANGE: 'cache' was renamed 'seed'