### PR TITLE
changed default filename from 'manifest.json' to 'manifest.webmanifest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module.exports = {
 };
 ```
 
-This will generate a `manifest.json` file in your root output directory with a mapping of all source file names to their corresponding output file, for example:
+This will generate a `manifest.webmanifest` file in your root output directory with a mapping of all source file names to their corresponding output file, for example:
 
 ```json
 {
@@ -60,7 +60,7 @@ A path prefix that will be added to values of the manifest.
 ### `options.fileName`
 
 Type: `String`<br>
-Default: `manifest.json`
+Default: `manifest.webmanifest`
 
 The manifest filename in your output directory.
 
@@ -85,7 +85,7 @@ If set to `true` will emit to build folder and memory in combination with `webpa
 Type: `Object`<br>
 Default: `{}`
 
-A cache of key/value pairs to used to seed the manifest. This may include a set of [custom key/value](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json) pairs to include in your manifest, or may be used to combine manifests across compilations in [multi-compiler mode](https://github.com/webpack/webpack/tree/master/examples/multi-compiler). To combine manifests, pass a shared seed object to each compiler's ManifestPlugin instance.
+A cache of key/value pairs to used to seed the manifest. This may include a set of [custom key/value](https://developer.mozilla.org/en-US/docs/Web/Manifest) pairs to include in your manifest, or may be used to combine manifests across compilations in [multi-compiler mode](https://github.com/webpack/webpack/tree/master/examples/multi-compiler). To combine manifests, pass a shared seed object to each compiler's ManifestPlugin instance.
 
 ### `options.filter`
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,7 +8,7 @@ var lock = mutexify();
 function ManifestPlugin(opts) {
   this.opts = _.assign({
     basePath: '',
-    fileName: 'manifest.json',
+    fileName: 'manifest.webmanifest',
     transformExtensions: /^(gz|map)$/i,
     writeToFileEmit: false,
     seed: null,

--- a/spec/plugin.integration.spec.js
+++ b/spec/plugin.integration.spec.js
@@ -54,7 +54,7 @@ describe('ManifestPlugin using real fs', function() {
           new ManifestPlugin()
         ]
       }, {}, function() {
-        var manifest = JSON.parse(fse.readFileSync(path.join(__dirname, 'output/single-file/manifest.json')))
+        var manifest = JSON.parse(fse.readFileSync(path.join(__dirname, 'output/single-file/manifest.webmanifest')))
 
         expect(manifest).toBeDefined();
         expect(manifest).toEqual({
@@ -124,7 +124,7 @@ describe('ManifestPlugin using real fs', function() {
           new webpack.HotModuleReplacementPlugin()
         ]
       }, {}, function(stats) {
-        var manifest = JSON.parse(fse.readFileSync(path.join(__dirname, 'output/watch-mode/manifest.json')))
+        var manifest = JSON.parse(fse.readFileSync(path.join(__dirname, 'output/watch-mode/manifest.webmanifest')))
 
         expect(manifest).toBeDefined();
         expect(manifest).toEqual({
@@ -170,13 +170,13 @@ describe('ManifestPlugin using real fs', function() {
             var compiler = this;
 
             compiler.plugin('after-emit', function(compilation, cb) {
-              JSON.parse(fse.readFileSync(path.join(__dirname, 'output/multiple-compilation/manifest.json')));
+              JSON.parse(fse.readFileSync(path.join(__dirname, 'output/multiple-compilation/manifest.webmanifest')));
               cb();
             });
           }
         ]
       })), {}, function() {
-        var manifest = JSON.parse(fse.readFileSync(path.join(__dirname, 'output/multiple-compilation/manifest.json')))
+        var manifest = JSON.parse(fse.readFileSync(path.join(__dirname, 'output/multiple-compilation/manifest.webmanifest')))
 
         expect(manifest).toBeDefined();
         expect(manifest).toEqual(Array.from({length: nbCompiler}).reduce((manifest, x, i) => {
@@ -279,7 +279,7 @@ describe('ManifestPlugin with memory-fs', function() {
       }, {
         outputFileSystem: new MemoryFileSystem()
       }, function() {
-        var manifest = JSON.parse(fse.readFileSync(path.join(__dirname, 'output/emit/manifest.json')))
+        var manifest = JSON.parse(fse.readFileSync(path.join(__dirname, 'output/emit/manifest.webmanifest')))
 
         expect(manifest).toBeDefined();
         expect(manifest).toEqual({

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -8,7 +8,7 @@ var FakeCopyWebpackPlugin = require('./helpers/copy-plugin-mock');
 var plugin = require('../index.js');
 
 var OUTPUT_DIR = path.join(__dirname, './webpack-out');
-var manifestPath = path.join(OUTPUT_DIR, 'manifest.json');
+var manifestPath = path.join(OUTPUT_DIR, 'manifest.webmanifest');
 
 function webpackConfig (webpackOpts, opts) {
   return _.merge({
@@ -360,7 +360,7 @@ describe('ManifestPlugin', function() {
           'main.js': 'main.js'
         });
 
-        expect(JSON.parse(stats.compilation.assets['manifest.json'].source())).toEqual({
+        expect(JSON.parse(stats.compilation.assets['manifest.webmanifest'].source())).toEqual({
           'main.js': 'main.js'
         });
 


### PR DESCRIPTION
Thanks for this plugin! 👍 

This pull requests changes the default filename from `manifest.json` to `manifest.webmanifest` because this is (now) the recommended filename and extension by the W3C:
* https://www.w3.org/TR/appmanifest/#media-type-registration
* https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest

Here is the discussion:
* https://github.com/w3c/manifest/issues/346
* https://github.com/w3c/manifest/issues/381

Some browser vendors also already adopted there docs:
* https://developer.mozilla.org/en-US/docs/Web/Manifest

_I would consider this a major change so maybe this is something for the major 2.0 release?_