### PR TITLE
Check module has user request

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -35,9 +35,12 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
   compiler.plugin("compilation", function (compilation) {
     compilation.plugin('module-asset', function (module, file) {
+      if (!module.userRequest) {
+        return;
+      }
       moduleAssets[file] = path.join(
-          path.dirname(file),
-          path.basename(module.userRequest)
+        path.dirname(file),
+        path.basename(module.userRequest)
       );
     });
   });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -35,7 +35,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
   compiler.plugin("compilation", function (compilation) {
     compilation.plugin('module-asset', function (module, file) {
-      if (!module.userRequest) {
+      if (module.userRequest != null) {
         return;
       }
       moduleAssets[file] = path.join(


### PR DESCRIPTION
Not all modules have the `userRequest`. Specifically modules generated by the `webpack.optimize.ModuleConcatenationPlugin`.

This PR prevents an error being thrown when using `webpack.optimize.ModuleConcatenationPlugin`.