### PR TITLE
add outputFormatter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ All entries in `files` correspond to the object structure described in the `Hook
 
 Create the manifest. It can return anything as long as it's serialisable by `JSON.stringify`. [more details](#hooks-options)
 
+### `options.outputFormatter`
+
+Type: `function`<br>
+Default: `(manifest) => JSON.stringify(manifest, null, 2)`
+
+Output manifest file in different format then json (i.e. yaml).
 
 ## Hooks Options
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ All entries in `files` correspond to the object structure described in the `Hook
 
 Create the manifest. It can return anything as long as it's serialisable by `JSON.stringify`. [more details](#hooks-options)
 
-### `options.outputFormatter`
+### `options.serialize`
 
 Type: `function`<br>
 Default: `(manifest) => JSON.stringify(manifest, null, 2)`

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -16,6 +16,9 @@ function ManifestPlugin(opts) {
     map: null,
     generate: null,
     sort: null,
+    outputFormatter: function(manifest) {
+      return JSON.stringify(manifest, null, 2);
+    },
   }, opts || {});
 }
 
@@ -151,7 +154,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }, seed);
     }
 
-    var json = JSON.stringify(manifest, null, 2);
+    var output = this.opts.outputFormatter(manifest);
 
     var outputFolder = compilation.options.output.path;
     var outputFile = path.resolve(compilation.options.output.path, this.opts.fileName);
@@ -159,15 +162,15 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
     compilation.assets[outputName] = {
       source: function() {
-        return json;
+        return output;
       },
       size: function() {
-        return json.length;
+        return output.length;
       }
     };
 
     if (this.opts.writeToFileEmit) {
-      fse.outputFileSync(outputFile, json);
+      fse.outputFileSync(outputFile, output);
     }
 
     // NOTE: make sure webpack is not writing multiple manifests simultaneously

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -16,7 +16,7 @@ function ManifestPlugin(opts) {
     map: null,
     generate: null,
     sort: null,
-    outputFormatter: function(manifest) {
+    serialize: function(manifest) {
       return JSON.stringify(manifest, null, 2);
     },
   }, opts || {});
@@ -154,7 +154,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }, seed);
     }
 
-    var output = this.opts.outputFormatter(manifest);
+    var output = this.opts.serialize(manifest);
 
     var outputFolder = compilation.options.output.path;
     var outputFile = path.resolve(compilation.options.output.path, this.opts.fileName);

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -759,5 +759,34 @@ describe('ManifestPlugin', function() {
         done();
       });
     });
+
+    describe('using relative path', function() {
+      it('should use output to the correct location', function(done) {
+        webpackCompile({
+          context: __dirname,
+          entry: './fixtures/file.js'
+        }, {
+          manifestOptions: {
+            fileName: 'webpack.manifest.yml',
+            outputFormatter: function(manifest) {
+              var output = '';
+              for (var key in manifest) {
+                output += '- ' + key + ': "' + manifest[key] + '"\n';
+              }
+              return output;
+            },
+          }
+        }, function(manifest, stats, fs) {
+          var OUTPUT_DIR = path.join(__dirname, './webpack-out');
+          var manifestPath = path.join(OUTPUT_DIR, 'webpack.manifest.yml');
+
+          var manifest =fs.readFileSync(manifestPath).toString();
+
+          expect(manifest).toEqual('- main.js: "main.js"\n');
+
+          done();
+        });
+      });
+    });
   });
 });

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -760,32 +760,30 @@ describe('ManifestPlugin', function() {
       });
     });
 
-    describe('using relative path', function() {
-      it('should use output to the correct location', function(done) {
-        webpackCompile({
-          context: __dirname,
-          entry: './fixtures/file.js'
-        }, {
-          manifestOptions: {
-            fileName: 'webpack.manifest.yml',
-            outputFormatter: function(manifest) {
-              var output = '';
-              for (var key in manifest) {
-                output += '- ' + key + ': "' + manifest[key] + '"\n';
-              }
-              return output;
-            },
-          }
-        }, function(manifest, stats, fs) {
-          var OUTPUT_DIR = path.join(__dirname, './webpack-out');
-          var manifestPath = path.join(OUTPUT_DIR, 'webpack.manifest.yml');
+    it('supports custom serializer using serialize option', function(done) {
+      webpackCompile({
+        context: __dirname,
+        entry: './fixtures/file.js'
+      }, {
+        manifestOptions: {
+          fileName: 'webpack.manifest.yml',
+          serialize: function(manifest) {
+            var output = '';
+            for (var key in manifest) {
+              output += '- ' + key + ': "' + manifest[key] + '"\n';
+            }
+            return output;
+          },
+        }
+      }, function(manifest, stats, fs) {
+        var OUTPUT_DIR = path.join(__dirname, './webpack-out');
+        var manifestPath = path.join(OUTPUT_DIR, 'webpack.manifest.yml');
 
-          var manifest =fs.readFileSync(manifestPath).toString();
+        var manifest =fs.readFileSync(manifestPath).toString();
 
-          expect(manifest).toEqual('- main.js: "main.js"\n');
+        expect(manifest).toEqual('- main.js: "main.js"\n');
 
-          done();
-        });
+        done();
       });
     });
   });


### PR DESCRIPTION
Support different manifest output formats.

In my case I need to generate manifest as yaml to load it as symfony config. With this I can replace JSON.stringify with YAML.stringify in my webpack configuration.