### PR TITLE
fix: always run hooks last for `webpack@4`

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -203,15 +203,19 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
   if (compiler.hooks) {
     const SyncWaterfallHook = require('tapable').SyncWaterfallHook;
+    const pluginOptions = {
+      name: 'ManifestPlugin',
+      stage: Infinity
+    };
     compiler.hooks.webpackManifestPluginAfterEmit = new SyncWaterfallHook(['manifest']);
 
-    compiler.hooks.compilation.tap('ManifestPlugin', function (compilation) {
-      compilation.hooks.moduleAsset.tap('ManifestPlugin', moduleAsset);
+    compiler.hooks.compilation.tap(pluginOptions, function (compilation) {
+      compilation.hooks.moduleAsset.tap(pluginOptions, moduleAsset);
     });
-    compiler.hooks.emit.tap('ManifestPlugin', emit);
+    compiler.hooks.emit.tap(pluginOptions, emit);
 
-    compiler.hooks.run.tap('ManifestPlugin', beforeRun);
-    compiler.hooks.watchRun.tap('ManifestPlugin', beforeRun);
+    compiler.hooks.run.tap(pluginOptions, beforeRun);
+    compiler.hooks.watchRun.tap(pluginOptions, beforeRun);
   } else {
     compiler.plugin('compilation', function (compilation) {
       compilation.plugin('module-asset', moduleAsset);


### PR DESCRIPTION
fixes #141 