### PR TITLE
move emitCountMap to support multiple webpack configs

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,8 +2,6 @@ var path = require('path');
 var fse = require('fs-extra');
 var _ = require('lodash');
 
-const emitCountMap = new Map();
-
 function ManifestPlugin(opts) {
   this.opts = _.assign({
     publicPath: null,
@@ -33,6 +31,7 @@ ManifestPlugin.prototype.getFileType = function(str) {
 };
 
 ManifestPlugin.prototype.apply = function(compiler) {
+  const emitCountMap = new Map();
   var moduleAssets = {};
 
   var outputFolder = compiler.options.output.path;


### PR DESCRIPTION
only one manifest file was written for multiple configs:
```
const Webpack = require('webpack')
const WebpackDevServer = require('webpack-dev-server')
const config1 = {...}
const config2 = {...}
const config3 = {...}
const config4 = {...}

const compiler = Webpack([config1, config2, config3, config4])
const server = new WebpackDevServer(compiler, devServerConfig)
server.listen(PORT, HOST)
```

moved the emitCountMap into the apply function. before it was global and shared between the plugin instances.