### PR TITLE
feat: supports overwriting outputPath of the manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Type: `String`
 
 A path prefix for all keys. Useful for including your output path in the manifest.
 
+### `options.outputPath`
+
+Type: `String`
+Default: `output.path`
+
+Overwrites the default manifest output directory.
 
 ### `options.writeToFileEmit`
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -7,6 +7,7 @@ const emitCountMap = new Map();
 function ManifestPlugin(opts) {
   this.opts = _.assign({
     publicPath: null,
+    outputPath: null,
     basePath: '',
     fileName: 'manifest.json',
     transformExtensions: /^(gz|map)$/i,
@@ -35,9 +36,9 @@ ManifestPlugin.prototype.getFileType = function(str) {
 ManifestPlugin.prototype.apply = function(compiler) {
   var moduleAssets = {};
 
-  var outputFolder = compiler.options.output.path;
-  var outputFile = path.resolve(outputFolder, this.opts.fileName);
-  var outputName = path.relative(outputFolder, outputFile);
+  var outputPath = this.opts.outputPath != null ? this.opts.outputPath : compiler.options.output.path;
+  var outputFile = path.resolve(outputPath, this.opts.fileName);
+  var outputName = path.relative(outputPath, outputFile);
 
   var moduleAsset = function (module, file) {
     moduleAssets[file] = path.join(
@@ -115,7 +116,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       // Don't add hot updates to manifest
       var isUpdateChunk = file.path.indexOf('hot-update') >= 0;
       // Don't add manifest from another instance
-      var isManifest = emitCountMap.get(path.join(outputFolder, file.name)) !== undefined;
+      var isManifest = emitCountMap.get(path.join(outputPath, file.name)) !== undefined;
 
       return !isUpdateChunk && !isManifest;
     });


### PR DESCRIPTION
I'm in the situation where the manifest should be written to a different path then the default Webpack (output) path.

This option is also supported by [assets-webpack-plugin](https://github.com/kossnocorp/assets-webpack-plugin) but it seems to not support Webpack 4 properly.

This PR is similar to #139, but misses the changes to `plugin.spec.js` because I'm not familiar with the test suite.