### PR TITLE
Fix high memory usage (#173)

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -55,7 +55,13 @@ ManifestPlugin.prototype.apply = function(compiler) {
     var seed = this.opts.seed || {};
 
     var publicPath = this.opts.publicPath != null ? this.opts.publicPath : compilation.options.output.publicPath;
-    var stats = compilation.getStats().toJson();
+    var stats = compilation.getStats().toJson({
+        // Disable data generation of everything we don't use
+        all: false,
+
+        // Enable generation of `assets` data
+        assets: true,
+    });
 
     var files = compilation.chunks.reduce(function(files, chunk) {
       return chunk.files.reduce(function (files, path) {


### PR DESCRIPTION
Fixes #173 

The `toJson()` call can use a lot of memory by generating a lot of stats information about modules.
But we don't use this information for this plugin, so we can only enable the generation of assets related data used for this plugin.

Read #173 for more information