### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - '9'
+  - 'node'
+  - '10'
   - '8'
   - '6'
 


### PR DESCRIPTION
Node.js 9 has reached its EOL. We should not use any odd release branches as these are short living and will not become LTS. This PR tests against LTS 10 and current stable (11, fail early).