### PR TITLE
Update README to note abs output location option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module.exports = {
 Type: `String`<br>
 Default: `manifest.json`
 
-The manifest filename in your output directory.
+By default the plugin will emit `manifest.json` to your output directory. Can override with an absolute path. 
 
 ### `options.publicPath`
 


### PR DESCRIPTION
Updates README to note that fileName can accept a path to a location. 