### PR TITLE
Pass `entrypoints` param to `generate` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Sort files before they are passed to `generate`. [FileDescriptor typings](#filed
 
 ### `options.generate`
 
-Type: `Function(Object, FileDescriptor): Object`<br>
-Default: `(seed, files) => files.reduce((manifest, {name, path}) => ({...manifest, [name]: path}), seed)`
+Type: `Function(Object, FileDescriptor, string[]): Object`<br>
+Default: `(seed, files, entrypoints) => files.reduce((manifest, {name, path}) => ({...manifest, [name]: path}), seed)`
 
 Create the manifest. It can return anything as long as it's serialisable by `JSON.stringify`. [FileDescriptor typings](#filedescriptor)
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -161,7 +161,12 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
     var manifest;
     if (this.opts.generate) {
-      manifest = this.opts.generate(seed, files);
+      const entrypointsArray = Array.from(Object.entries(compilation.entrypoints));
+      const entrypoints = entrypointsArray.reduce((e, [name, entrypoint]) => ({
+        ...e,
+        [name]: entrypoint.getFiles()
+      }), {});
+      manifest = this.opts.generate(seed, files, entrypoints);
     } else {
       manifest = files.reduce(function (manifest, file) {
         manifest[file.name] = file.path;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -161,7 +161,13 @@ ManifestPlugin.prototype.apply = function(compiler) {
 
     var manifest;
     if (this.opts.generate) {
-      const entrypointsArray = Array.from(Object.entries(compilation.entrypoints));
+      const entrypointsArray = Array.from(
+        compilation.entrypoints instanceof Map ?
+          // Webpack 4+
+          compilation.entrypoints.entries() :
+          // Webpack 3
+          Object.entries(compilation.entrypoints)
+      );
       const entrypoints = entrypointsArray.reduce((e, [name, entrypoint]) => ({
         ...e,
         [name]: entrypoint.getFiles()

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -745,6 +745,44 @@ describe('ManifestPlugin', function() {
     });
   });
 
+  it('should generate manifest with "entrypoints" key', done => {
+    webpackCompile({
+      context: __dirname,
+      entry: {
+        one: './fixtures/file.js',
+        two: './fixtures/file-two.js'
+      }
+    },
+    {
+      manifestOptions: {
+        generate: (seed, files, entrypoints) => {
+          const manifestFiles = files.reduce((manifest, { name, path }) => ({
+            ...manifest,
+            [name]: path
+          }), seed);
+          return {
+            files: manifestFiles,
+            entrypoints
+          };
+        }
+      }
+    },
+    (manifest, stats) => {
+      expect(manifest).toEqual({
+        entrypoints: {
+          one: ['one.js'],
+          two: ['two.js']
+        },
+        files: {
+          'one.js': 'one.js',
+          'two.js': 'two.js'
+        }
+      });
+
+      done();
+    });
+  });
+
   describe('with CopyWebpackPlugin', function () {
     it('works when including copied assets', function (done) {
       webpackCompile({


### PR DESCRIPTION
We are using `create-react-app` and would like to generate the `index.html` file on the server. In order to get code splitting to work, we need to know which code chunks are entrypoints of the React app (to be able to request these from the HTML file).

In https://github.com/facebook/create-react-app/issues/5513#issuecomment-486838664, it was suggested to add an `"entrypoints"` key to `create-react-app`'s `asset-manifest.json` file with a list of these chunks (in the order they need to be included).

This PR passes an additional parameter called `entrypoints` to the `generate` function, which provides enough information to be able to build such a manifest file.