### PR TITLE
Fix `entrypoints` compatibility for older Node versions

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,23 +1,9 @@
+var entries = require('object.entries');
 var path = require('path');
 var fse = require('fs-extra');
 var _ = require('lodash');
 
 const emitCountMap = new Map();
-
-// Polyfill for `Object.entries`
-// Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
-// TODO: Remove once support for older versions of Node.js is dropped
-if (!Object.entries) {
-  Object.entries = function( obj ){
-    var ownProps = Object.keys( obj ),
-        i = ownProps.length,
-        resArray = new Array(i); // preallocate the Array
-    while (i--)
-      resArray[i] = [ownProps[i], obj[ownProps[i]]];
-
-    return resArray;
-  };
-}
 
 function ManifestPlugin(opts) {
   this.opts = _.assign({
@@ -181,7 +167,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
           // Webpack 4+
           compilation.entrypoints.entries() :
           // Webpack 3
-          Object.entries(compilation.entrypoints)
+          entries(compilation.entrypoints)
       );
       const entrypoints = entrypointsArray.reduce(
         (e, [name, entrypoint]) => Object.assign(e, { [name]: entrypoint.getFiles() }),

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,6 +4,21 @@ var _ = require('lodash');
 
 const emitCountMap = new Map();
 
+// Polyfill for `Object.entries`
+// Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
+// TODO: Remove once support for older versions of Node.js is dropped
+if (!Object.entries) {
+  Object.entries = function( obj ){
+    var ownProps = Object.keys( obj ),
+        i = ownProps.length,
+        resArray = new Array(i); // preallocate the Array
+    while (i--)
+      resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+    return resArray;
+  };
+}
+
 function ManifestPlugin(opts) {
   this.opts = _.assign({
     publicPath: null,
@@ -168,10 +183,10 @@ ManifestPlugin.prototype.apply = function(compiler) {
           // Webpack 3
           Object.entries(compilation.entrypoints)
       );
-      const entrypoints = entrypointsArray.reduce((e, [name, entrypoint]) => ({
-        ...e,
-        [name]: entrypoint.getFiles()
-      }), {});
+      const entrypoints = entrypointsArray.reduce(
+        (e, [name, entrypoint]) => Object.assign(e, { [name]: entrypoint.getFiles() }),
+        {}
+      );
       manifest = this.opts.generate(seed, files, entrypoints);
     } else {
       manifest = files.reduce(function (manifest, file) {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "fs-extra": "^7.0.0",
     "lodash": ">=3.5 <5",
+    "object.entries": "^1.1.0",
     "tapable": "^1.0.0"
   },
   "jest": {

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -756,10 +756,10 @@ describe('ManifestPlugin', function() {
     {
       manifestOptions: {
         generate: (seed, files, entrypoints) => {
-          const manifestFiles = files.reduce((manifest, { name, path }) => ({
-            ...manifest,
-            [name]: path
-          }), seed);
+          const manifestFiles = files.reduce(
+            (manifest, { name, path }) => Object.assign(manifest, { [name]: path }),
+            seed
+          );
           return {
             files: manifestFiles,
             entrypoints


### PR DESCRIPTION
I've introduced changes in #192 that aren't compatible with some older versions of Node.js. This PR fixes that. It can be reverted once the required Node.js version is increased.

Fixes #193