### PR TITLE
Webpack 5: Add "ids" to the retrieved JSON stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
 
 env:
   - WEBPACK_VERSION=4
+  - WEBPACK_VERSION=next
 
 install:
   - npm install

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -77,6 +77,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
         all: false,
         // Add asset Information
         assets: true,
+        ids: true, // needed by Webpack 5
         // Show cached assets (setting this to `false` only shows emitted files)
         cachedAssets: true,
     });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,4 +1,3 @@
-var entries = require('object.entries');
 var path = require('path');
 var fse = require('fs-extra');
 var _ = require('lodash');

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,6 +4,13 @@ var fse = require('fs-extra');
 var _ = require('lodash');
 
 const emitCountMap = new Map();
+const compilerHookMap = new WeakMap();
+
+const standardizeFilePaths = (file) => {
+  file.name = file.name.replace(/\\/g, '/');
+  file.path = file.path.replace(/\\/g, '/');
+  return file;
+};
 
 function ManifestPlugin(opts) {
   this.opts = _.assign({
@@ -23,6 +30,18 @@ function ManifestPlugin(opts) {
   }, opts || {});
 }
 
+ManifestPlugin.getCompilerHooks = (compiler) => {
+  var hooks = compilerHookMap.get(compiler);
+  if (hooks === undefined) {
+    const SyncWaterfallHook = require('tapable').SyncWaterfallHook;
+    hooks = {
+      afterEmit: new SyncWaterfallHook(['manifest'])
+    };
+    compilerHookMap.set(compiler, hooks);
+  }
+  return hooks;
+}
+
 ManifestPlugin.prototype.getFileType = function(str) {
   str = str.replace(/\?.*/, '');
   var split = str.split('.');
@@ -39,15 +58,6 @@ ManifestPlugin.prototype.apply = function(compiler) {
   var outputFolder = compiler.options.output.path;
   var outputFile = path.resolve(outputFolder, this.opts.fileName);
   var outputName = path.relative(outputFolder, outputFile);
-
-  var moduleAsset = function (module, file) {
-    if (module.userRequest) {
-      moduleAssets[file] = path.join(
-        path.dirname(file),
-        path.basename(module.userRequest)
-      );
-    }
-  };
 
   // TODO: check with @evilebottnawi if this is still needed for webpack@5
   var normalModuleLoader = function (loaderContext, module) {
@@ -163,18 +173,14 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }.bind(this));
     }
 
-    files = files.map(file => {
-      file.name = file.name.replace(/\\/g, '/');
-      file.path = file.path.replace(/\\/g, '/');
-      return file;
-    });
+    files = files.map(standardizeFilePaths);
 
     if (this.opts.filter) {
       files = files.filter(this.opts.filter);
     }
 
     if (this.opts.map) {
-      files = files.map(this.opts.map);
+      files = files.map(this.opts.map).map(standardizeFilePaths);
     }
 
     if (this.opts.sort) {
@@ -214,11 +220,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }
     }
 
-    if (compiler.hooks) {
-      compiler.hooks.webpackManifestPluginAfterEmit.call(manifest);
-    } else {
-      compilation.applyPluginsAsync('webpack-manifest-plugin-after-emit', manifest, compileCallback);
-    }
+    ManifestPlugin.getCompilerHooks(compiler).afterEmit.call(manifest);
   }.bind(this);
 
   function beforeRun (compiler, callback) {
@@ -230,12 +232,16 @@ ManifestPlugin.prototype.apply = function(compiler) {
     }
   }
 
-  const SyncWaterfallHook = require('tapable').SyncWaterfallHook;
   const pluginOptions = {
     name: 'ManifestPlugin',
     stage: Infinity
   };
-  compiler.hooks.webpackManifestPluginAfterEmit = new SyncWaterfallHook(['manifest']);
+
+  // Preserve exposure of custom hook in Webpack 4 for back compatability.
+  // Going forward, plugins should call `ManifestPlugin.getCompilerHooks(compiler)` directy.
+  if (!Object.isFrozen(compiler.hooks)) {
+    compiler.hooks.webpackManifestPluginAfterEmit = ManifestPlugin.getCompilerHooks(compiler).afterEmit;
+  }
 
   compiler.hooks.compilation.tap(pluginOptions, function (compilation) {
     compilation.hooks.normalModuleLoader.tap(pluginOptions, normalModuleLoader);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-manifest-plugin",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "webpack plugin for generating asset manifests",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "fs-extra": "^8.1.0",
     "lodash": "^4",
-    "object.entries": "^1.1.0",
     "tapable": "^1.1.3"
   },
   "jest": {

--- a/spec/helpers/webpack-version-helpers.js
+++ b/spec/helpers/webpack-version-helpers.js
@@ -1,0 +1,14 @@
+var webpack = require('webpack');
+
+const isWebpackVersionGte = (minVersion) => webpack.version && parseInt(webpack.version.slice(0, 1)) >= minVersion;
+
+const emittedAsset = (compilation, assetName) => {
+  return isWebpackVersionGte(5) ?
+    compilation.emittedAssets.has(assetName) :
+    compilation.assets[assetName].emitted;
+}
+
+module.exports = {
+    emittedAsset,
+    isWebpackVersionGte
+};

--- a/spec/plugin.integration.spec.js
+++ b/spec/plugin.integration.spec.js
@@ -12,11 +12,11 @@ var ManifestPlugin = require('../index.js');
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 5 * 60 * 1000;
 
 function applyDefaultWebpackConfig(webpackOpts) {
-  var defaults = isWebpackVersionGte(4) ? {
+  var defaults = {
     optimization: {
       chunkIds: 'natural',
     }
-  } : {};
+  };
   return _.merge(defaults, webpackOpts);
 }
 
@@ -246,19 +246,34 @@ describe('ManifestPlugin using real fs', function() {
         expect(manifest).toBeDefined();
 
         if (isFirstRun) {
-          expect(manifest).toEqual({
-            'main.js': 'main.js',
-            '1.js': '1.js',
-            '2.js': '2.js'
-          });
+          if (isWebpackVersionGte(5)) {
+            expect(manifest).toEqual({
+              'main.js': 'main.js',
+              '0.js': '0.js',
+              '2.js': '2.js'
+            });
+          } else {
+            expect(manifest).toEqual({
+              'main.js': 'main.js',
+              '1.js': '1.js',
+              '2.js': '2.js'
+            });
+          }
 
           isFirstRun = false;
           fse.outputFileSync(path.join(__dirname, 'output/watch-import-chunk/index.js'), 'import(\'./chunk1\')');
         } else {
-          expect(manifest).toEqual({
-            'main.js': 'main.js',
-            '1.js': '1.js',
-          });
+          if (isWebpackVersionGte(5)) {
+            expect(manifest).toEqual({
+              'main.js': 'main.js',
+              '2.js': '2.js',
+            });
+          } else {
+            expect(manifest).toEqual({
+              'main.js': 'main.js',
+              '1.js': '1.js',
+            });
+          }
 
           done();
         }

--- a/spec/plugin.integration.spec.js
+++ b/spec/plugin.integration.spec.js
@@ -5,19 +5,30 @@ var _ = require('lodash');
 var webpack = require('webpack');
 var MemoryFileSystem = require('memory-fs');
 var rimraf = require('rimraf');
+var { emittedAsset, isWebpackVersionGte } = require('./helpers/webpack-version-helpers');
 
 var ManifestPlugin = require('../index.js');
 
-function webpackConfig(webpackOpts, opts) {
-  return _.merge({
-    plugins: [
-      new ManifestPlugin(opts.manifestOptions)
-    ]
-  }, webpackOpts);
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 5 * 60 * 1000;
+
+function applyDefaultWebpackConfig(webpackOpts) {
+  var defaults = isWebpackVersionGte(4) ? {
+    optimization: {
+      chunkIds: 'natural',
+    }
+  } : {};
+  return _.merge(defaults, webpackOpts);
+}
+
+function webpackConfig(webpackOpts) {
+  if (Array.isArray(webpackOpts)) {
+    return webpackOpts.map(opts => applyDefaultWebpackConfig(opts));
+  }
+  return applyDefaultWebpackConfig(webpackOpts);
 }
 
 function webpackWatch(config, compilerOps, cb) {
-  var compiler = webpack(config);
+  var compiler = webpack(webpackConfig(config));
 
   _.assign(compiler, compilerOps);
 
@@ -33,7 +44,7 @@ function webpackWatch(config, compilerOps, cb) {
 };
 
 function webpackCompile(config, compilerOps, cb) {
-  var compiler = webpack(config);
+  var compiler = webpack(webpackConfig(config));
 
   _.assign(compiler, compilerOps);
 
@@ -87,10 +98,9 @@ describe('ManifestPlugin using real fs', function() {
           new ManifestPlugin({fileName: 'manifest2.json'})
         ]
       }, {}, function(stats) {
-
-        expect(stats.compilation.assets['main.js'].emitted).toBe(true);
-        expect(stats.compilation.assets['manifest1.json'].emitted).toBe(true);
-        expect(stats.compilation.assets['manifest2.json'].emitted).toBe(true);
+        expect(emittedAsset(stats.compilation, 'main.js')).toBe(true);
+        expect(emittedAsset(stats.compilation, 'manifest1.json')).toBe(true);
+        expect(emittedAsset(stats.compilation, 'manifest2.json')).toBe(true);
 
         var manifest1 = fse.readJsonSync(path.join(__dirname, 'output/single-file/manifest1.json'))
         expect(manifest1).toBeDefined();
@@ -114,7 +124,13 @@ describe('ManifestPlugin using real fs', function() {
       }
       TestPlugin.prototype.apply = function (compiler) {
         if (compiler.hooks) {
-          compiler.hooks.webpackManifestPluginAfterEmit.tap('ManifestPlugin', (manifest) => {
+          let hook;
+          if (Object.isFrozen(compiler.hooks)) {
+            hook = ManifestPlugin.getCompilerHooks(compiler).afterEmit;
+          } else {
+            hook = compiler.hooks.webpackManifestPluginAfterEmit;
+          }
+          hook.tap('ManifestPlugin', (manifest) => {
             this.manifest = manifest;
           })
         } else {

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -7,7 +7,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 var FakeCopyWebpackPlugin = require('./helpers/copy-plugin-mock');
 var plugin = require('../index.js');
-var { emittedAsset, isWebpackVersionGte } = require('./helpers/webpack-version-helpers');
+var { isWebpackVersionGte } = require('./helpers/webpack-version-helpers');
 
 var OUTPUT_DIR = path.join(__dirname, './webpack-out');
 var manifestPath = path.join(OUTPUT_DIR, 'manifest.json');
@@ -20,11 +20,11 @@ function webpackConfig (webpackOpts, opts) {
     },
     plugins: [
       new plugin(opts.manifestOptions)
-    ]
+    ],
+    optimization: {
+      chunkIds: 'named'
+    }
   };
-  if (isWebpackVersionGte(4)) {
-    defaults.optimization = { chunkIds:  'named' };
-  }
   return _.merge(defaults, webpackOpts);
 }
 

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -7,12 +7,13 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 var FakeCopyWebpackPlugin = require('./helpers/copy-plugin-mock');
 var plugin = require('../index.js');
+var { emittedAsset, isWebpackVersionGte } = require('./helpers/webpack-version-helpers');
 
 var OUTPUT_DIR = path.join(__dirname, './webpack-out');
 var manifestPath = path.join(OUTPUT_DIR, 'manifest.json');
 
 function webpackConfig (webpackOpts, opts) {
-  return _.merge({
+  var defaults = {
     output: {
       path: OUTPUT_DIR,
       filename: '[name].js'
@@ -20,7 +21,11 @@ function webpackConfig (webpackOpts, opts) {
     plugins: [
       new plugin(opts.manifestOptions)
     ]
-  }, webpackOpts);
+  };
+  if (isWebpackVersionGte(4)) {
+    defaults.optimization = { chunkIds:  'named' };
+  }
+  return _.merge(defaults, webpackOpts);
 }
 
 function webpackCompile(webpackOpts, opts, cb) {
@@ -46,8 +51,9 @@ function webpackCompile(webpackOpts, opts, cb) {
       manifestFile = null
     }
 
-
-    expect(err).toBeFalsy();
+    if (err) {
+      throw err;
+    }
     expect(stats.hasErrors()).toBe(false);
 
     cb(manifestFile, stats, fs);
@@ -389,22 +395,25 @@ describe('ManifestPlugin', function() {
       });
     });
 
-    it('make manifest available to other webpack plugins', function(done) {
-      webpackCompile({
-        context: __dirname,
-        entry: './fixtures/file.js'
-      }, {}, function(manifest, stats) {
-        expect(manifest).toEqual({
-          'main.js': 'main.js'
-        });
+    // Webpack 5 doesn't include file content in stats.compilation.assets
+    if (!isWebpackVersionGte(5)) {
+      it('make manifest available to other webpack plugins', function(done) {
+        webpackCompile({
+          context: __dirname,
+          entry: './fixtures/file.js'
+        }, {}, function(manifest, stats) {
+          expect(manifest).toEqual({
+            'main.js': 'main.js'
+          });
 
-        expect(JSON.parse(stats.compilation.assets['manifest.json'].source())).toEqual({
-          'main.js': 'main.js'
-        });
+          expect(JSON.parse(stats.compilation.assets['manifest.json'].source())).toEqual({
+            'main.js': 'main.js'
+          });
 
-        done();
+          done();
+        });
       });
-    });
+    }
 
     it('should output unix paths', function(done) {
       webpackCompile({
@@ -660,7 +669,7 @@ describe('ManifestPlugin', function() {
         expect(manifest).toEqual({
           'main.js': {
             file: 'main.js',
-            hash: stats.compilation.chunks[0].hash
+            hash: Array.from(stats.compilation.chunks)[0].hash
           }
         });
 


### PR DESCRIPTION
This PR adds the `ids` objects to the stats retrieved by `stats.toJson()`.

It is needed by the latest alpha of Webpack 5 (`v5.0.0-alpha.31`) in order to retrieve `asset.chunks` later on (see https://github.com/webpack/webpack/pull/9793#pullrequestreview-300371456).

Without it, the following error is thrown by the plugin:

```
TypeError: Cannot read property 'length' of undefined
    at (...)/node_modules/webpack-manifest-plugin/lib/plugin.js:128:39
```

Related: #186 