### PR TITLE
fix: use CommonJS import for webpack-sources

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -5,12 +5,14 @@ import { SyncWaterfallHook } from 'tapable';
 import type { Compiler, Module, Compilation, LoaderContext } from 'webpack';
 // Note: This was the old delcaration. It appears to be Webpack v3 compat.
 // const { RawSource } = (webpack as any).sources || require('webpack-sources');
-import { RawSource } from 'webpack-sources';
+import webpackSources from 'webpack-sources';
 
 import type { EmitCountMap, InternalOptions } from './index.js';
 
 import type { CompilationAsset, FileDescriptor } from './helpers.js';
 import { generateManifest, reduceAssets, reduceChunk, transformFiles } from './helpers.js';
+
+const { RawSource } = webpackSources;
 
 interface BeforeRunHookArgs {
   emitCountMap: EmitCountMap;

--- a/test/integration/usage.ts
+++ b/test/integration/usage.ts
@@ -1,0 +1,14 @@
+import { execSync } from 'node:child_process';
+
+import test from '../helpers/ava-compat';
+
+// make implicit dependency explicit:
+import '../../src/index';
+
+test.before(() => execSync('pnpm build'));
+
+test('can be used as documented', (t) => {
+  const readmeCode = "import { WebpackManifestPlugin } from 'webpack-manifest-plugin'";
+
+  t.deepEqual(execSync(`node -e "${readmeCode}"`, { encoding: 'utf-8' }), '');
+});


### PR DESCRIPTION
webpack-sources is a CommonJS module and requires default import syntax in ESM. This fixes the package import to work with Node's ESM loader.

Fixes #313

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

See #313
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
